### PR TITLE
Speed up `unit_convert`

### DIFF
--- a/src/libdenavit/unit_convert.py
+++ b/src/libdenavit/unit_convert.py
@@ -4,59 +4,59 @@ ureg = pint.UnitRegistry()
 def unit_conversion_factor(old_unit, new_unit):
     return unit_convert(1,old_unit,new_unit)
 
-def unit_convert(old_value: float or int, old_unit: str, new_unit: str): 
+def unit_convert(old_value: float or int, old_unit: str, new_unit: str):
     """
     **Defined units to use:**
         Length Units: in, ft, m, cm, mm
-        
+
         Curvature units: 1/in, 1/mm, 1/m
-        
-        Time Units: s, second, min, h, hr    
-        
+
+        Time Units: s, second, min, h, hr
+
         Force Units: kip, kips, lbf, kn, mn, n, metricton, tonne, longton, shortton
-        
+
         Moment Units: kin, k-in, kip-in, kft, k-ft, kip-ft, lbft, lb-ft, nmm, n-mm,
         knm, kn-m, mnm, mn-m, tfm, tf-m
-        
+
         Pressure Units: psi, psf, ksi, mpa, n/mm^2 kpa, gpa, kn/cm^2, kgcm, tscm, metricton/cm^2,
         longton/in^2, shortton/in^2
-        
+
         Density Units: pcf, kgcm
-        
+
         Angle Units: rad, deg
-        
+
         Volume Units: cbin, cbft, cbyd, cbm, cbmm
     """
-    
+
     old_unit = old_unit.strip()
     new_unit = new_unit.strip()
-    
+
     units_for_pint = {  ## Length
                         "in": ureg.inch, # inch
                         "ft": ureg.ft,   # foot
                         "m" : ureg.m,    # meter
                         "cm": ureg.cm,   # centimeter
                         "mm": ureg.mm,   # milimeter
-        
+
                         ## Area
                         "sqin": ureg.inch ** 2, # inch^2
                         "sqft": ureg.ft ** 2,   # foot^2
                         "sqm": ureg.m ** 2,    # meter^2
                         "sqcm": ureg.cm ** 2,  # centimeter^2
                         "sqmm": ureg.mm ** 2,  # milimeter^2
-        
+
                         ## Curvature
                         "1/in": 1/ureg.inch, # 1/inch
                         "1/mm": 1/ureg.mm,   # 1/millimeter
                         "1/m" : 1/ureg.m,    # 1/meter
-                        
+
                         ## Time
                         "s"     : ureg.second, # second
                         "second": ureg.second, # second
                         "min"   : ureg.minute, # minute
                         "h"     : ureg.hour,   # hour
                         "hr"    : ureg.hour,   # hour
-                        
+
                         ## Force
                         "kip"      : ureg.kip,              # kip
                         "kips"     : ureg.kip,              # kip
@@ -68,7 +68,7 @@ def unit_convert(old_value: float or int, old_unit: str, new_unit: str):
                         "tonne"    : ureg.force_metric_ton, # tonne
                         "longton"  : ureg.force_long_ton,   # long ton
                         "shortton" : ureg.force_ton,        # short ton
-                        
+
                         ## Moment
                         'kin'   : ureg.kforce_pound*ureg.inch,      # kilo pound-inch
                         'k-in'  : ureg.kforce_pound*ureg.inch,      # kilo pound-inch
@@ -86,7 +86,7 @@ def unit_convert(old_value: float or int, old_unit: str, new_unit: str):
                         'mn-m'  : ureg.mnewton*ureg.meter,          # millinewton meter
                         'tfm'   : ureg.force_metric_ton*ureg.meter, # metric ton-force meter
                         'tf-m'  : ureg.force_metric_ton*ureg.meter, # metric ton-force meter
-                        
+
                         ## Pressure
                         'psi'           : ureg.psi,                         # pound per inch^2
                         'psf'           : ureg.force_pound/ureg.foot**2,    # pound per foot^2
@@ -101,7 +101,7 @@ def unit_convert(old_value: float or int, old_unit: str, new_unit: str):
                         'metricton/cm^2': ureg.force_metric_ton/ureg.cm**2, # metric tonne per cm^2
                         'longton/in^2'  : ureg.force_long_ton/ureg.inch**2, # long ton per inch^2
                         'shortton/in^2' : ureg.force_ton/ureg.inch**2,      # short ton per inch^2
-                        
+
                         ## Density
                         'pcf' : ureg.pound/ureg.ft**3,      # pounds per cubic foot
                         'kgcm': ureg.metric_ton/ureg.cm**3, # metric tonne per cm^2
@@ -109,7 +109,7 @@ def unit_convert(old_value: float or int, old_unit: str, new_unit: str):
                         ## Angle
                         'rad': ureg.radian, # radian
                         'deg': ureg.degree, # degree
-                        
+
                         ## Volume
                         'cbin': ureg.inch**3,  # cubic inch
                         'cbft': ureg.ft**3,    # cubic foot
@@ -117,8 +117,8 @@ def unit_convert(old_value: float or int, old_unit: str, new_unit: str):
                         'cbm' : ureg.meter**3, # cubic meter
                         'cbmm': ureg.mmeter**3 # cubic millimeter
                      }
-    
+
     value_with_unit = old_value*units_for_pint[old_unit.lower()]
     new_value = value_with_unit.to(units_for_pint[new_unit.lower()]).magnitude
-    
+
     return new_value

--- a/src/libdenavit/unit_convert.py
+++ b/src/libdenavit/unit_convert.py
@@ -1,10 +1,13 @@
+from typing import Union
+
 import pint
+
 ureg = pint.UnitRegistry()
 
-def unit_conversion_factor(old_unit, new_unit):
-    return unit_convert(1,old_unit,new_unit)
+def unit_conversion_factor(old_unit: str, new_unit: str) -> float:
+    return unit_convert(1, old_unit, new_unit)
 
-def unit_convert(old_value: float or int, old_unit: str, new_unit: str):
+def unit_convert(old_value: Union[float, int], old_unit: str, new_unit: str) -> float:
     """
     **Defined units to use:**
         Length Units: in, ft, m, cm, mm

--- a/src/libdenavit/unit_convert.py
+++ b/src/libdenavit/unit_convert.py
@@ -3,9 +3,98 @@ from typing import Union
 import pint
 
 ureg = pint.UnitRegistry()
+units_for_pint = {
+    ## Length
+    "in": ureg.inch, # inch
+    "ft": ureg.ft,   # foot
+    "m" : ureg.m,    # meter
+    "cm": ureg.cm,   # centimeter
+    "mm": ureg.mm,   # milimeter
+
+    ## Area
+    "sqin": ureg.inch ** 2, # inch^2
+    "sqft": ureg.ft ** 2,   # foot^2
+    "sqm": ureg.m ** 2,    # meter^2
+    "sqcm": ureg.cm ** 2,  # centimeter^2
+    "sqmm": ureg.mm ** 2,  # milimeter^2
+
+    ## Curvature
+    "1/in": 1/ureg.inch, # 1/inch
+    "1/mm": 1/ureg.mm,   # 1/millimeter
+    "1/m" : 1/ureg.m,    # 1/meter
+
+    ## Time
+    "s"     : ureg.second, # second
+    "second": ureg.second, # second
+    "min"   : ureg.minute, # minute
+    "h"     : ureg.hour,   # hour
+    "hr"    : ureg.hour,   # hour
+
+    ## Force
+    "kip"      : ureg.kip,              # kip
+    "kips"     : ureg.kip,              # kip
+    "lbf"      : ureg.lbf,              # pound-force
+    "kn"       : ureg.knewton,          # kilonewton
+    "mn"       : ureg.meganewton,       # meganewton
+    "n"        : ureg.newton,           # kilonewton
+    "metricton": ureg.force_metric_ton, # tonne
+    "tonne"    : ureg.force_metric_ton, # tonne
+    "longton"  : ureg.force_long_ton,   # long ton
+    "shortton" : ureg.force_ton,        # short ton
+
+    ## Moment
+    'kin'   : ureg.kforce_pound*ureg.inch,      # kilo pound-inch
+    'k-in'  : ureg.kforce_pound*ureg.inch,      # kilo pound-inch
+    'kip-in': ureg.kforce_pound*ureg.inch,      # kilo pound-inch
+    'kft'   : ureg.kforce_pound*ureg.foot,      # kilo pound-foot
+    'k-ft'  : ureg.kforce_pound*ureg.foot,      # kilo pound-foot
+    'kip-ft': ureg.kforce_pound*ureg.foot,      # kilo pound-foot
+    'lbft'  : ureg.foot_pound,                  # pound-foot
+    'lb-ft' : ureg.foot_pound,                  # pound-foot
+    'nmm'   : ureg.newton*ureg.millimeter,      # newton-milimeter
+    'n-mm'  : ureg.newton*ureg.millimeter,      # newton-milimeter
+    'knm'   : ureg.knewton*ureg.meter,          # kilo newton-milimeter
+    'kn-m'  : ureg.knewton*ureg.meter,          # kilo newton-milimeter
+    'mnm'   : ureg.mnewton*ureg.meter,          # millinewton meter
+    'mn-m'  : ureg.mnewton*ureg.meter,          # millinewton meter
+    'tfm'   : ureg.force_metric_ton*ureg.meter, # metric ton-force meter
+    'tf-m'  : ureg.force_metric_ton*ureg.meter, # metric ton-force meter
+
+    ## Pressure
+    'psi'           : ureg.psi,                         # pound per inch^2
+    'psf'           : ureg.force_pound/ureg.foot**2,    # pound per foot^2
+    'ksi'           : ureg.kpsi,                        # killo pound per foot^2
+    'mpa'           : ureg.megaPa,                      # megapascal
+    'n/mm^2'        : ureg.megaPa,                      # newton per millimeter^2
+    'kpa'           : ureg.kPa,                         # killopascal
+    'gpa'           : ureg.gigaPa,                      # gigapascal
+    'kn/cm^2'       : ureg.knewton/ureg.cm**2,          # killo-newton/centimeter^2
+    'kgscm'         : ureg.kilogram_force/ureg.cm**2,   # Kilograms Per Square Centimeter
+    'tscm'          : ureg.force_metric_ton/ureg.cm**2, # metric tonne per cm^2
+    'metricton/cm^2': ureg.force_metric_ton/ureg.cm**2, # metric tonne per cm^2
+    'longton/in^2'  : ureg.force_long_ton/ureg.inch**2, # long ton per inch^2
+    'shortton/in^2' : ureg.force_ton/ureg.inch**2,      # short ton per inch^2
+
+    ## Density
+    'pcf' : ureg.pound/ureg.ft**3,      # pounds per cubic foot
+    'kgcm': ureg.metric_ton/ureg.cm**3, # metric tonne per cm^2
+
+    ## Angle
+    'rad': ureg.radian, # radian
+    'deg': ureg.degree, # degree
+
+    ## Volume
+    'cbin': ureg.inch**3,  # cubic inch
+    'cbft': ureg.ft**3,    # cubic foot
+    'cbyd': ureg.yard**3,  # cubic yard
+    'cbm' : ureg.meter**3, # cubic meter
+    'cbmm': ureg.mmeter**3 # cubic millimeter
+}
+
 
 def unit_conversion_factor(old_unit: str, new_unit: str) -> float:
     return unit_convert(1, old_unit, new_unit)
+
 
 def unit_convert(old_value: Union[float, int], old_unit: str, new_unit: str) -> float:
     """
@@ -33,93 +122,6 @@ def unit_convert(old_value: Union[float, int], old_unit: str, new_unit: str) -> 
 
     old_unit = old_unit.strip()
     new_unit = new_unit.strip()
-
-    units_for_pint = {  ## Length
-                        "in": ureg.inch, # inch
-                        "ft": ureg.ft,   # foot
-                        "m" : ureg.m,    # meter
-                        "cm": ureg.cm,   # centimeter
-                        "mm": ureg.mm,   # milimeter
-
-                        ## Area
-                        "sqin": ureg.inch ** 2, # inch^2
-                        "sqft": ureg.ft ** 2,   # foot^2
-                        "sqm": ureg.m ** 2,    # meter^2
-                        "sqcm": ureg.cm ** 2,  # centimeter^2
-                        "sqmm": ureg.mm ** 2,  # milimeter^2
-
-                        ## Curvature
-                        "1/in": 1/ureg.inch, # 1/inch
-                        "1/mm": 1/ureg.mm,   # 1/millimeter
-                        "1/m" : 1/ureg.m,    # 1/meter
-
-                        ## Time
-                        "s"     : ureg.second, # second
-                        "second": ureg.second, # second
-                        "min"   : ureg.minute, # minute
-                        "h"     : ureg.hour,   # hour
-                        "hr"    : ureg.hour,   # hour
-
-                        ## Force
-                        "kip"      : ureg.kip,              # kip
-                        "kips"     : ureg.kip,              # kip
-                        "lbf"      : ureg.lbf,              # pound-force
-                        "kn"       : ureg.knewton,          # kilonewton
-                        "mn"       : ureg.meganewton,       # meganewton
-                        "n"        : ureg.newton,           # kilonewton
-                        "metricton": ureg.force_metric_ton, # tonne
-                        "tonne"    : ureg.force_metric_ton, # tonne
-                        "longton"  : ureg.force_long_ton,   # long ton
-                        "shortton" : ureg.force_ton,        # short ton
-
-                        ## Moment
-                        'kin'   : ureg.kforce_pound*ureg.inch,      # kilo pound-inch
-                        'k-in'  : ureg.kforce_pound*ureg.inch,      # kilo pound-inch
-                        'kip-in': ureg.kforce_pound*ureg.inch,      # kilo pound-inch
-                        'kft'   : ureg.kforce_pound*ureg.foot,      # kilo pound-foot
-                        'k-ft'  : ureg.kforce_pound*ureg.foot,      # kilo pound-foot
-                        'kip-ft': ureg.kforce_pound*ureg.foot,      # kilo pound-foot
-                        'lbft'  : ureg.foot_pound,                  # pound-foot
-                        'lb-ft' : ureg.foot_pound,                  # pound-foot
-                        'nmm'   : ureg.newton*ureg.millimeter,      # newton-milimeter
-                        'n-mm'  : ureg.newton*ureg.millimeter,      # newton-milimeter
-                        'knm'   : ureg.knewton*ureg.meter,          # kilo newton-milimeter
-                        'kn-m'  : ureg.knewton*ureg.meter,          # kilo newton-milimeter
-                        'mnm'   : ureg.mnewton*ureg.meter,          # millinewton meter
-                        'mn-m'  : ureg.mnewton*ureg.meter,          # millinewton meter
-                        'tfm'   : ureg.force_metric_ton*ureg.meter, # metric ton-force meter
-                        'tf-m'  : ureg.force_metric_ton*ureg.meter, # metric ton-force meter
-
-                        ## Pressure
-                        'psi'           : ureg.psi,                         # pound per inch^2
-                        'psf'           : ureg.force_pound/ureg.foot**2,    # pound per foot^2
-                        'ksi'           : ureg.kpsi,                        # killo pound per foot^2
-                        'mpa'           : ureg.megaPa,                      # megapascal
-                        'n/mm^2'        : ureg.megaPa,                      # newton per millimeter^2
-                        'kpa'           : ureg.kPa,                         # killopascal
-                        'gpa'           : ureg.gigaPa,                      # gigapascal
-                        'kn/cm^2'       : ureg.knewton/ureg.cm**2,          # killo-newton/centimeter^2
-                        'kgscm'         : ureg.kilogram_force/ureg.cm**2,   # Kilograms Per Square Centimeter
-                        'tscm'          : ureg.force_metric_ton/ureg.cm**2, # metric tonne per cm^2
-                        'metricton/cm^2': ureg.force_metric_ton/ureg.cm**2, # metric tonne per cm^2
-                        'longton/in^2'  : ureg.force_long_ton/ureg.inch**2, # long ton per inch^2
-                        'shortton/in^2' : ureg.force_ton/ureg.inch**2,      # short ton per inch^2
-
-                        ## Density
-                        'pcf' : ureg.pound/ureg.ft**3,      # pounds per cubic foot
-                        'kgcm': ureg.metric_ton/ureg.cm**3, # metric tonne per cm^2
-
-                        ## Angle
-                        'rad': ureg.radian, # radian
-                        'deg': ureg.degree, # degree
-
-                        ## Volume
-                        'cbin': ureg.inch**3,  # cubic inch
-                        'cbft': ureg.ft**3,    # cubic foot
-                        'cbyd': ureg.yard**3,  # cubic yard
-                        'cbm' : ureg.meter**3, # cubic meter
-                        'cbmm': ureg.mmeter**3 # cubic millimeter
-                     }
 
     value_with_unit = old_value*units_for_pint[old_unit.lower()]
     new_value = value_with_unit.to(units_for_pint[new_unit.lower()]).magnitude


### PR DESCRIPTION
Moving the dict creation outside the function speeds up unit conversion 40-50x (on my machine -- 1.8ms/call to 40μs/call). Also fixes the typing annotations -- `float or int` doesn't work, need to use `typing.Union[float, int]` or `float | int` (the latter only in Python 3.10+).