### PR TITLE
Fix RC section and second-order analysis errors

### DIFF
--- a/examples/steel_column_curve.py
+++ b/examples/steel_column_curve.py
@@ -29,8 +29,8 @@ def run_single_analysis(L,residual_stress,material_options):
         eb=0.,
         axis='y',
         dxo=L/1000.0,
-        n_elem=8,
-        element_type='mixedBeamColumn',
+        ops_n_elem=8,
+        ops_element_type='mixedBeamColumn',
         ops_geom_transf_type='Corotational',
         ops_integration_points=3,
     )

--- a/src/libdenavit/analysis_helpers.py
+++ b/src/libdenavit/analysis_helpers.py
@@ -1,6 +1,19 @@
 from libdenavit import opensees as ops
 
 
+EIGENVALUE_LIMIT = 'Eigenvalue Limit Reached'
+DEFORMATION_LIMIT = 'Deformation Limit Reached'
+CONCRETE_COMPRESSION_STRAIN_LIMIT = 'Concrete Compression Strain Limit Reached'
+STEEL_COMPRESSION_STRAIN_LIMIT = 'Steel Compression Strain Limit Reached'
+STEEL_TENSILE_STRAIN_LIMIT = 'Steel Tensile Strain Limit Reached'
+
+# Earlier spellings, kept so stored results and outside code still resolve.
+LEGACY_LIMIT_MESSAGES = {
+    'Extreme Compressive Concrete Fiber Strain Limit Reached': CONCRETE_COMPRESSION_STRAIN_LIMIT,
+    'Extreme Steel Fiber Strain Limit Reached': STEEL_TENSILE_STRAIN_LIMIT,
+}
+
+
 def try_analysis_options():
     """
     Tries different analysis algorithms and tolerances in OpenSees.
@@ -140,24 +153,24 @@ def check_analysis_limits(results, **limits):
     section_type = limits.get('section_type', 'RC')
 
     if eigenvalue_limit is not None and results.lowest_eigenvalue[-1] < eigenvalue_limit:
-        return 'Eigenvalue Limit Reached'
+        return EIGENVALUE_LIMIT
 
     if deformation_limit is not None and results.maximum_abs_disp[-1] > deformation_limit:
-            return 'Deformation Limit Reached'
+            return DEFORMATION_LIMIT
     
     if section_type == "RC":
         # For RC: Check concrete compression and steel tension
         if concrete_strain_limit is not None and results.maximum_concrete_compression_strain[-1] < concrete_strain_limit:
-            return 'Concrete Compression Strain Limit Reached'
+            return CONCRETE_COMPRESSION_STRAIN_LIMIT
         
         if steel_strain_limit is not None and results.maximum_steel_strain[-1] > steel_strain_limit:
-            return 'Steel Tensile Strain Limit Reached'
+            return STEEL_TENSILE_STRAIN_LIMIT
         
     elif section_type == "I_shape":
         # compression strains are negative; exceed limit if magnitude > steel_strain_limit
         if steel_strain_limit is not None and results.maximum_compression_strain[-1] < -steel_strain_limit:
-            return 'Steel Compression Strain Limit Reached'
+            return STEEL_COMPRESSION_STRAIN_LIMIT
         if steel_strain_limit is not None and results.maximum_tensile_strain[-1] > steel_strain_limit:
-            return 'Steel Tensile Strain Limit Reached'
+            return STEEL_TENSILE_STRAIN_LIMIT
 
     return None

--- a/src/libdenavit/analysis_helpers.py
+++ b/src/libdenavit/analysis_helpers.py
@@ -174,3 +174,29 @@ def check_analysis_limits(results, **limits):
             return STEEL_TENSILE_STRAIN_LIMIT
 
     return None
+
+
+def adapt_step_factor(step_factor, base_factor, recovered_div=None,
+                      growth=2.0, min_ratio=1e-6):
+    """
+    Step factor for the next analysis increment.
+
+    When an increment will not converge, the analysis retries it with a
+    smaller step. This decides what the increment after that should use.
+
+    - The last increment only converged after its step was divided by
+      recovered_div. Stay small, because the full step just failed and
+      retrying it would fail the same way. The step is not allowed below
+      min_ratio * base_factor, so it cannot shrink to nothing.
+    - The last increment converged on its own. Multiply the step by growth
+      so it climbs back toward base_factor, the step originally asked for,
+      and never past it.
+
+    The result is a plain multiplier, not a length or a load, so the same
+    number works for a DisplacementControl step or a LoadControl step.
+    """
+    if recovered_div:
+        return max(base_factor * min_ratio, step_factor / recovered_div)
+    return min(base_factor, step_factor * growth)
+
+

--- a/src/libdenavit/column_2d.py
+++ b/src/libdenavit/column_2d.py
@@ -1,4 +1,4 @@
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 from libdenavit.OpenSees import AnalysisResults
 from libdenavit import interpolate_list, find_limit_point_in_list
 from libdenavit.analysis_helpers import (
@@ -7,10 +7,19 @@ from libdenavit.analysis_helpers import (
 )
 import warnings
 
-class Column2d:
+class Column2d(ABC):
     """
     A base class for 2D column models.
     """
+    # Keyword arguments consumed by __init__. Subclasses extend this with their own,
+    # which lets a misspelled or unsupported argument be reported instead of silently
+    # ignored.
+    _INIT_KWARGS = frozenset({
+        'axis', 'dxo', 'include_initial_geometric_imperfections',
+        'ops_n_elem', 'ops_element_type',
+        'ops_geom_transf_type', 'ops_integration_points',
+    })
+
     def __init__(self, section, length, **kwargs):
         """
         Initializes common properties for a column.
@@ -32,6 +41,12 @@ class Column2d:
         self.dxo = kwargs.get('dxo', 0.0)
         self.include_initial_geometric_imperfections = kwargs.get('include_initial_geometric_imperfections', True)
         
+        unknown = set(kwargs) - self._INIT_KWARGS
+        if unknown:
+            warnings.warn(f'{type(self).__name__} ignoring unrecognized keyword '
+                          f'argument(s): {sorted(unknown)}')
+
+
     def _init_results(self, attrs: list) -> AnalysisResults:
         """Create an AnalysisResults with the given attribute names as empty lists."""
         results = AnalysisResults()

--- a/src/libdenavit/column_2d.py
+++ b/src/libdenavit/column_2d.py
@@ -1,6 +1,10 @@
 from abc import abstractmethod
 from libdenavit.OpenSees import AnalysisResults
 from libdenavit import interpolate_list, find_limit_point_in_list
+from libdenavit.analysis_helpers import (
+    CONCRETE_COMPRESSION_STRAIN_LIMIT, DEFORMATION_LIMIT, EIGENVALUE_LIMIT,
+    LEGACY_LIMIT_MESSAGES, STEEL_COMPRESSION_STRAIN_LIMIT, STEEL_TENSILE_STRAIN_LIMIT,
+)
 import warnings
 
 class Column2d:
@@ -81,32 +85,51 @@ class Column2d:
         results.maximum_abs_moment_at_limit_point = interpolate_list(results.maximum_abs_moment, ind, x)
         results.maximum_abs_disp_at_limit_point = interpolate_list(results.maximum_abs_disp, ind, x)
     
-    def _find_limit_point(self, results, config, analysis_type=None):
-        """Find and set limit point values."""
-        if 'Analysis Failed' in results.exit_message:
-            ind, x = find_limit_point_in_list(results.applied_axial_load, max(results.applied_axial_load))
-            warnings.warn('Analysis failed')
-        elif 'Eigenvalue Limit' in results.exit_message:
-            ind, x = find_limit_point_in_list(results.lowest_eigenvalue, config['eigenvalue_limit'])
-        elif 'Extreme Compressive Concrete Fiber Strain Limit Reached' in results.exit_message:
-            ind, x = find_limit_point_in_list(results.maximum_concrete_compression_strain, config['concrete_strain_limit'])
-        elif 'Extreme Steel Fiber Strain Limit Reached' in results.exit_message:
-            ind, x = find_limit_point_in_list(results.maximum_steel_strain, config['steel_strain_limit'])
-        elif 'Deformation Limit Reached' in results.exit_message:
-            ind, x = find_limit_point_in_list(results.maximum_abs_disp, config['deformation_limit'])
-        elif 'Load Drop Limit Reached' in results.exit_message:
-            ind, x = find_limit_point_in_list(results.applied_axial_load, max(results.applied_axial_load))
-        elif 'Analysis failed while maintaining sustained load' in results.exit_message:
-            ind, x = find_limit_point_in_list(results.applied_axial_load, max(results.applied_axial_load))
-        elif 'Analysis failed before full sustained load is reached' in results.exit_message:
-            ind, x = find_limit_point_in_list(results.applied_axial_load, max(results.applied_axial_load))
-        elif 'Analysis failed on the first step of maintaining sustained load' in results.exit_message:
-            ind, x = find_limit_point_in_list(results.applied_axial_load, max(results.applied_axial_load))
-        else:
-            # No message at all → set one & fallback
-            results.exit_message = 'Analysis Ended Without Explicit Limit'
-            ind, x = find_limit_point_in_list(results.applied_axial_load, max(results.applied_axial_load))
+    def _peak_response(self, results, analysis_type=None):
+        """Series and target for messages that name no quantity: the peak applied load.
 
+        Override where a different load drives the analysis.
+        """
+        return results.applied_axial_load, max(results.applied_axial_load)
+
+    def _limit_point_sources(self, results, config):
+        """Map each limit message to the (series, target) whose crossing sets the limit point."""
+        is_rc = type(self.section).__name__ == 'RC'
+        return {
+            EIGENVALUE_LIMIT:
+                (results.lowest_eigenvalue, config['eigenvalue_limit']),
+            DEFORMATION_LIMIT:
+                (results.maximum_abs_disp, config['deformation_limit']),
+            CONCRETE_COMPRESSION_STRAIN_LIMIT:
+                (results.maximum_concrete_compression_strain, config['concrete_strain_limit']),
+            # Compression strains are negative, so the limit is crossed going down.
+            STEEL_COMPRESSION_STRAIN_LIMIT:
+                (results.maximum_compression_strain, -config['steel_strain_limit']),
+            # RC records the bar strain, I_shape the extreme tensile fiber strain.
+            STEEL_TENSILE_STRAIN_LIMIT:
+                (results.maximum_steel_strain if is_rc else results.maximum_tensile_strain,
+                 config['steel_strain_limit']),
+        }
+
+    def _find_limit_point(self, results, config, analysis_type=None):
+        """Locate the limit point and store its values on results.
+
+        A message naming a quantity is resolved through _limit_point_sources, so the
+        limit point is interpolated at the exact crossing. Everything else, including
+        analysis failures and load drops, falls back to the peak applied load.
+        """
+        if not results.exit_message:
+            results.exit_message = 'Analysis Ended Without Explicit Limit'
+
+        if 'analysis failed' in results.exit_message.lower():
+            warnings.warn(f'Analysis failed: {results.exit_message}')
+
+        message = LEGACY_LIMIT_MESSAGES.get(results.exit_message, results.exit_message)
+        source = self._limit_point_sources(results, config).get(message)
+        if source is None:
+            source = self._peak_response(results, analysis_type)
+
+        ind, x = find_limit_point_in_list(*source)
         self._set_limit_point_values(results, ind, x)
     
     def run_ops_analysis(self, analysis_type, **kwargs):

--- a/src/libdenavit/column_2d.py
+++ b/src/libdenavit/column_2d.py
@@ -68,6 +68,7 @@ class Column2d(ABC):
             'P': kwargs.get('P', 0),
             'num_steps_vertical': kwargs.get('num_steps_vertical', 1000),
             'disp_incr_factor': kwargs.get('disp_incr_factor', 1e-5),
+            'axial_control': kwargs.get('axial_control', 'load'),
             'eigenvalue_limit': kwargs.get('eigenvalue_limit', 0),
             'deformation_limit': kwargs.get('deformation_limit', 'default'),
             'concrete_strain_limit': kwargs.get('concrete_strain_limit', -0.01),
@@ -81,7 +82,11 @@ class Column2d(ABC):
         # Set default deformation limit using subclass override
         if config['deformation_limit'] == 'default':
             config['deformation_limit'] = self._get_default_deformation_limit()
-            
+
+        if config['axial_control'] not in ('load', 'displacement'):
+            raise ValueError(f"axial_control must be 'load' or 'displacement', "
+                             f"got {config['axial_control']!r}")
+
         return config
     
     def _initialize_results(self):

--- a/src/libdenavit/interaction_diagram_2d.py
+++ b/src/libdenavit/interaction_diagram_2d.py
@@ -163,21 +163,27 @@ class InteractionDiagram2d():
 
 
     def find_x_given_y(self, Y, signX):
+        """Capacity in x at the given y, as a scalar."""
         X_list = []
         if type(Y) in [int, float, np.float64]:
             Y_list = [Y]
         for y in Y_list:
             if signX.lower() in ['+', 'positive', 'pos']:
                 peakX = 1.1 * np.max(self.idx)
+                extreme = np.max
             elif signX.lower() in ['-', 'negative', 'neg']:
                 peakX = 1.1 * np.min(self.idx)
+                extreme = np.min
             else:
                 raise ValueError('signX must be positive or negative')
 
             npts = 10
             pathX = np.linspace(0, peakX, npts)
             pathY = y * np.ones(npts)
-            X_list.append(self.find_intersection(pathX, pathY)[0])
+            crossings = self.find_intersection(pathX, pathY)[0]
+            if isinstance(crossings, (list, tuple, np.ndarray)):
+                crossings = float(extreme(crossings)) if len(crossings) else float('nan')
+            X_list.append(crossings)
 
         if type(Y) in [int, float, np.float64]:
             return X_list[0]

--- a/src/libdenavit/non_sway_column_2d.py
+++ b/src/libdenavit/non_sway_column_2d.py
@@ -75,11 +75,15 @@ class NonSwayColumn2d(Column2d):
         return 15 + 0.03 * h  # mm
 
 
-    def _aci_first_order_moment(self, M_top, M_bot, P):
+    def _aci_first_order_moment(self, M_top, M_bot, P, apply_minimum=True):
         """
         First-order moment for the ACI 6.2.5.3 1.4 check (M2/M1 <= 1.4).
+
+        Pass apply_minimum=False to use the raw applied moment instead.
         """
         applied = max(abs(M_top), abs(M_bot))
+        if not apply_minimum:
+            return applied
         return max(applied, abs(P) * self._aci_minimum_eccentricity)
 
 
@@ -1276,6 +1280,7 @@ class NonSwayColumn2d(Column2d):
         eigenvalue_limit = kwargs.get('eigenvalue_limit', 0.0)
         deformation_limit = kwargs.get('deformation_limit', 0.1 * self.length)
         max_1_4_Mu_limit = kwargs.get('max_1_4_Mu_limit', True)
+        apply_minimum_moment = kwargs.get('apply_minimum_moment', True)
         section_factored = kwargs.get('section_factored', False)
         # ACI 318-19 (6.6.4.5.4) covers member out-of-straightness through the
         # minimum moment Mmin = Pu*(0.6 + 0.03h). This routine emulates the code
@@ -1500,7 +1505,8 @@ class NonSwayColumn2d(Column2d):
                 # first-order moment for the ratio to be measured against.
                 if max_1_4_Mu_limit is True and not (e == 0 or (abs(et) < 1e-12 and abs(eb) < 1e-12)):
                     first_order = self._aci_first_order_moment(
-                        results.applied_moment_top[-1], results.applied_moment_bot[-1], P_check)
+                        results.applied_moment_top[-1], results.applied_moment_bot[-1], P_check,
+                        apply_minimum=apply_minimum_moment)
                     if first_order > 0 and 1.4 * first_order <= results.maximum_abs_moment[-1]:
                         results.exit_message = 'max_1_4_Mu_limit_reached'
                         break
@@ -1692,7 +1698,8 @@ class NonSwayColumn2d(Column2d):
                         if et == 0 and eb == 0:
                             continue  # Skip for axial-only columns
                         applied_1_4_Mu = 1.4 * self._aci_first_order_moment(
-                            results.applied_moment_top[-1], results.applied_moment_bot[-1], P_check)
+                            results.applied_moment_top[-1], results.applied_moment_bot[-1], P_check,
+                            apply_minimum=apply_minimum_moment)
                         if applied_1_4_Mu > M_check:
                             max_1_4_Mu_armed = True
                         elif max_1_4_Mu_armed:
@@ -1806,6 +1813,17 @@ class NonSwayColumn2d(Column2d):
                 'M1': Array of first-order moments
                 'M2': Array of second-order moments
                 'exit_message': List of exit messages for each point
+
+        Additional keyword arguments:
+            max_1_4_Mu_limit: Enforce the ACI 318-19 (6.2.5.3) limit that the
+                              second-order moment not exceed 1.4 times the
+                              first-order moment. Default True.
+            apply_minimum_moment: Measure that ratio against the minimum moment
+                              of ACI 318-19 (6.6.4.5.4), Mmin = P*(0.6+0.03h),
+                              where the applied moment is smaller, and report M1
+                              on the same basis. Default True. Set False to work
+                              from the applied moment alone, e.g. when studying
+                              eccentricities below the code minimum.
         """
         
         section_id = kwargs.get('section_id', 1)
@@ -1813,6 +1831,8 @@ class NonSwayColumn2d(Column2d):
         prop_disp_incr_factor = kwargs.get('prop_disp_incr_factor', 1e-6)
         nonprop_disp_incr_factor = kwargs.get('nonprop_disp_incr_factor', 1e-5)
         section_factored = kwargs.get('section_factored', False)
+        max_1_4_Mu_limit = kwargs.get('max_1_4_Mu_limit', True)
+        apply_minimum_moment = kwargs.get('apply_minimum_moment', True)
         e = kwargs.get('e', 1.0)
         # 1. Get Elastic Buckling Load (P_cr_elastic)
         logger.debug('Running proportional analysis for elastic buckling load...')
@@ -1821,6 +1841,8 @@ class NonSwayColumn2d(Column2d):
             e=0,
             section_id=section_id,
             section_factored=section_factored,
+            max_1_4_Mu_limit=max_1_4_Mu_limit,
+            apply_minimum_moment=apply_minimum_moment,
             disp_incr_factor=prop_disp_incr_factor)
 
         P_cr_elastic = results_pcr.applied_axial_load_at_limit_point
@@ -1870,6 +1892,8 @@ class NonSwayColumn2d(Column2d):
                     e=e,
                     section_id=section_id,
                     section_factored=section_factored,
+                    max_1_4_Mu_limit=max_1_4_Mu_limit,
+                    apply_minimum_moment=apply_minimum_moment,
                     disp_incr_factor=nonprop_disp_incr_factor
                 )
 
@@ -1877,7 +1901,8 @@ class NonSwayColumn2d(Column2d):
                 P.append(iP)
                 M1.append(self._aci_first_order_moment(
                     results.applied_moment_top_at_limit_point,
-                    results.applied_moment_bot_at_limit_point, iP))
+                    results.applied_moment_bot_at_limit_point, iP,
+                    apply_minimum=apply_minimum_moment))
                 M2.append(results.maximum_abs_moment_at_limit_point)
                 exit_message.append(results.exit_message)
 

--- a/src/libdenavit/non_sway_column_2d.py
+++ b/src/libdenavit/non_sway_column_2d.py
@@ -84,19 +84,10 @@ class NonSwayColumn2d(Column2d):
         return 15 + 0.03 * h  # mm
 
 
-    def _aci_first_order_moment(self, M_top, M_bot, P, apply_minimum=True):
-        """
-        First-order moment for the ACI 6.2.5.3 1.4 check (M2/M1 <= 1.4).
-
-        Pass apply_minimum=False to use the raw applied moment instead.
-
-        Independent of apply_minimum_eccentricity, which changes the loading
-        itself; this only changes what M1 is measured against.
-        """
-        applied = max(abs(M_top), abs(M_bot))
-        if not apply_minimum:
-            return applied
-        return max(applied, abs(P) * self._aci_minimum_eccentricity)
+    @staticmethod
+    def _applied_first_order_moment(M_top, M_bot):
+        """Largest applied end moment, the M1 of the ACI 6.2.5.3 1.4 check."""
+        return max(abs(M_top), abs(M_bot))
 
 
     def _apply_aci_minimum_eccentricity(self, et, eb):
@@ -104,9 +95,8 @@ class NonSwayColumn2d(Column2d):
         Raise the dominant end eccentricity to the ACI 318-19 minimum.
 
         Applied once at construction when apply_minimum_eccentricity is set, so
-        it changes the loading seen by every analysis. Independent of the
-        apply_minimum_moment option of the ACI elastic analyses, which is a
-        checking and reporting basis only. See _aci_first_order_moment.
+        every analysis sees the corrected loading. This is the only place the
+        minimum eccentricity is enforced.
         """
         e_min = self._aci_minimum_eccentricity
         e_max = max(abs(et), abs(eb))
@@ -1316,7 +1306,6 @@ class NonSwayColumn2d(Column2d):
         eigenvalue_limit = kwargs.get('eigenvalue_limit', 0.0)
         deformation_limit = kwargs.get('deformation_limit', 0.1 * self.length)
         max_1_4_Mu_limit = kwargs.get('max_1_4_Mu_limit', True)
-        apply_minimum_moment = kwargs.get('apply_minimum_moment', True)
         section_factored = kwargs.get('section_factored', False)
         # ACI 318-19 (6.6.4.5.4) covers member out-of-straightness through the
         # minimum moment Mmin = Pu*(0.6 + 0.03h). This routine emulates the code
@@ -1566,12 +1555,10 @@ class NonSwayColumn2d(Column2d):
                 # ACI 6.2.5.3: flag a column whose second-order moment has
                 # amplified past 1.4x its first-order moment. Skipped for
                 # axial-only loading, where there is no first-order moment to
-                # measure against. See _aci_first_order_moment for why M1 is
-                # floored at Mmin.
+                # measure against.
                 if max_1_4_Mu_limit is True and not (e == 0 or (abs(et) < 1e-12 and abs(eb) < 1e-12)):
-                    first_order = self._aci_first_order_moment(
-                        results.applied_moment_top[-1], results.applied_moment_bot[-1], P_check,
-                        apply_minimum=apply_minimum_moment)
+                    first_order = self._applied_first_order_moment(
+                        results.applied_moment_top[-1], results.applied_moment_bot[-1])
                     if first_order > 0 and 1.4 * first_order <= results.maximum_abs_moment[-1]:
                         results.exit_message = 'max_1_4_Mu_limit_reached'
                         break
@@ -1760,13 +1747,11 @@ class NonSwayColumn2d(Column2d):
                     
                     if max_1_4_Mu_limit:
                         # ACI 6.2.5.3: flag a column whose second-order moment
-                        # has amplified past 1.4x its first-order moment. See
-                        # _aci_first_order_moment for why M1 is floored at Mmin.
+                        # has amplified past 1.4x its first-order moment.
                         if et == 0 and eb == 0:
                             continue  # Skip for axial-only columns
-                        applied_1_4_Mu = 1.4 * self._aci_first_order_moment(
-                            results.applied_moment_top[-1], results.applied_moment_bot[-1], P_check,
-                            apply_minimum=apply_minimum_moment)
+                        applied_1_4_Mu = 1.4 * self._applied_first_order_moment(
+                            results.applied_moment_top[-1], results.applied_moment_bot[-1])
                         if applied_1_4_Mu > M_check:
                             max_1_4_Mu_armed = True
                         elif max_1_4_Mu_armed:
@@ -1885,12 +1870,9 @@ class NonSwayColumn2d(Column2d):
             max_1_4_Mu_limit: Enforce the ACI 318-19 (6.2.5.3) limit that the
                               second-order moment not exceed 1.4 times the
                               first-order moment. Default True.
-            apply_minimum_moment: Measure that ratio against the minimum moment
-                              of ACI 318-19 (6.6.4.5.4), Mmin = P*(0.6+0.03h),
-                              where the applied moment is smaller, and report M1
-                              on the same basis. Default True. Set False to work
-                              from the applied moment alone, e.g. when studying
-                              eccentricities below the code minimum.
+
+        The ACI 318-19 (6.6.4.5.4) minimum eccentricity is applied to the
+        loading, by constructing the column with apply_minimum_eccentricity.
         """
         
         section_id = kwargs.get('section_id', 1)
@@ -1899,7 +1881,6 @@ class NonSwayColumn2d(Column2d):
         nonprop_disp_incr_factor = kwargs.get('nonprop_disp_incr_factor', 1e-5)
         section_factored = kwargs.get('section_factored', False)
         max_1_4_Mu_limit = kwargs.get('max_1_4_Mu_limit', True)
-        apply_minimum_moment = kwargs.get('apply_minimum_moment', True)
         e = kwargs.get('e', 1.0)
         # 1. Get Elastic Buckling Load (P_cr_elastic)
         logger.debug('Running proportional analysis for elastic buckling load...')
@@ -1909,7 +1890,6 @@ class NonSwayColumn2d(Column2d):
             section_id=section_id,
             section_factored=section_factored,
             max_1_4_Mu_limit=max_1_4_Mu_limit,
-            apply_minimum_moment=apply_minimum_moment,
             disp_incr_factor=prop_disp_incr_factor)
 
         P_cr_elastic = results_pcr.applied_axial_load_at_limit_point
@@ -1960,16 +1940,14 @@ class NonSwayColumn2d(Column2d):
                     section_id=section_id,
                     section_factored=section_factored,
                     max_1_4_Mu_limit=max_1_4_Mu_limit,
-                    apply_minimum_moment=apply_minimum_moment,
                     disp_incr_factor=nonprop_disp_incr_factor
                 )
 
                 # Record whatever we got at the limit point
                 P.append(iP)
-                M1.append(self._aci_first_order_moment(
+                M1.append(self._applied_first_order_moment(
                     results.applied_moment_top_at_limit_point,
-                    results.applied_moment_bot_at_limit_point, iP,
-                    apply_minimum=apply_minimum_moment))
+                    results.applied_moment_bot_at_limit_point))
                 M2.append(results.maximum_abs_moment_at_limit_point)
                 exit_message.append(results.exit_message)
 

--- a/src/libdenavit/non_sway_column_2d.py
+++ b/src/libdenavit/non_sway_column_2d.py
@@ -323,7 +323,9 @@ class NonSwayColumn2d(Column2d):
                     Pc = pi ** 2 * EIeff / (k * self.length) ** 2
                     error.append(buckling_load - Pc_factor * Pc)
 
-                M2 = M2_trials[error.index(min(error))]
+                # The trial closest to satisfying P == Pc_factor * Pc, i.e. the
+                # smallest residual magnitude -- not the most negative residual.
+                M2 = M2_trials[int(np.argmin(np.abs(error)))]
 
                 P_list.append(buckling_load)
                 M1_list.append(0)

--- a/src/libdenavit/non_sway_column_2d.py
+++ b/src/libdenavit/non_sway_column_2d.py
@@ -1490,7 +1490,12 @@ class NonSwayColumn2d(Column2d):
             # Run analysis
             max_applied_load = 0.0
             M_check = 0.0
-            P_check = 0.0  
+            P_check = 0.0
+            # Under proportional loading M2/M1 rises monotonically from about
+            # 1 + dxo/e, so it can start above the limit and never come back.
+            # Recording whether it was ever acceptable separates "amplified past
+            # the limit under load" from "over the limit at every load level".
+            prop_ratio_has_been_below_limit = False
             
             while True:
                 ok = ops.analyze(1)
@@ -1559,9 +1564,15 @@ class NonSwayColumn2d(Column2d):
                 if max_1_4_Mu_limit is True and not (e == 0 or (abs(et) < 1e-12 and abs(eb) < 1e-12)):
                     first_order = self._applied_first_order_moment(
                         results.applied_moment_top[-1], results.applied_moment_bot[-1])
-                    if first_order > 0 and 1.4 * first_order <= results.maximum_abs_moment[-1]:
-                        results.exit_message = 'max_1_4_Mu_limit_reached'
-                        break
+                    if first_order > 0:
+                        if 1.4 * first_order > results.maximum_abs_moment[-1]:
+                            prop_ratio_has_been_below_limit = True
+                        elif prop_ratio_has_been_below_limit:
+                            results.exit_message = 'max_1_4_Mu_limit_reached'
+                            break
+                        else:
+                            results.exit_message = 'max_1_4_Mu_limit_exceeded_at_all_loads'
+                            break
 
                 # Check deformation
                 if deformation_limit is not None:
@@ -1818,7 +1829,7 @@ class NonSwayColumn2d(Column2d):
             ind, x = find_limit_point_in_list(results.lowest_eigenvalue, eigenvalue_limit)
         elif 'Deformation' in results.exit_message:
             ind, x = find_limit_point_in_list(results.maximum_abs_disp, deformation_limit)
-        elif 'max_1_4_Mu_limit_reached' in results.exit_message:
+        elif 'max_1_4_Mu_limit' in results.exit_message:
             ind = len(results.applied_axial_load) - 2 # Go back to the point before the last
             x = 0.0
         else:

--- a/src/libdenavit/non_sway_column_2d.py
+++ b/src/libdenavit/non_sway_column_2d.py
@@ -409,17 +409,20 @@ class NonSwayColumn2d(Column2d):
                 k = 1  # Effective length factor (always one for this non-sway column)
 
                 trials = []
-                iM2_list = np.arange(0, iM2_section, iM2_section/1000)
-                for iM2 in iM2_list:
-                    EIeff = self.section.EIeff(self.axis, EI_type, beta_dns, P=iP, M=iM2, col=self)
+                for iM1_trial in np.linspace(0.0, iM2_section, 1000):
+                    EIeff = self.section.EIeff(self.axis, EI_type, beta_dns, P=iP, M=iM1_trial, col=self)
                     Pc = pi ** 2 * EIeff / (k * self.length) ** 2
-                    if Pc_factor * Pc < iP:
+                    if Pc_factor * Pc <= iP:
+                        # Unstable at this first-order moment; a larger moment
+                        # only softens the section further, so stop here.
                         break
 
                     delta = max(self.Cm / (1 - (iP) / (Pc_factor * Pc)), 1.0)
+                    iM2_trial = delta * iM1_trial
 
-                    if np.isfinite(iM2 / delta):
-                        trials.append((iM2 / delta, iM2))
+                    # The magnified moment still has to fit inside the section.
+                    if iM2_trial <= iM2_section:
+                        trials.append((iM1_trial, iM2_trial))
 
                 if trials:
                     iM1, iM2 = max(trials, key=lambda trial: trial[0])
@@ -428,7 +431,7 @@ class NonSwayColumn2d(Column2d):
             P_list.append(iP)
             M1_list.append(iM1)
             M2_list.append(iM2)
-            EIeff_list.append(self.section.EIeff(self.axis, EI_type, beta_dns, P=iP, M=iM2, col=self))
+            EIeff_list.append(self.section.EIeff(self.axis, EI_type, beta_dns, P=iP, M=iM1, col=self))
         results = {'P':np.array(P_list),'M1':np.array(M1_list),'M2':np.array(M2_list), 'EIeff':np.array(EIeff_list)}
         return results
 

--- a/src/libdenavit/non_sway_column_2d.py
+++ b/src/libdenavit/non_sway_column_2d.py
@@ -8,7 +8,7 @@ import warnings
 from scipy.optimize import fsolve
 import io
 import sys
-from libdenavit.analysis_helpers import try_analysis_options, ops_get_section_strains, ops_get_maximum_abs_moment, ops_get_maximum_abs_disp, check_analysis_limits
+from libdenavit.analysis_helpers import try_analysis_options, ops_get_section_strains, ops_get_maximum_abs_moment, ops_get_maximum_abs_disp, check_analysis_limits, adapt_step_factor
 from libdenavit.column_2d import Column2d
 import logging
 
@@ -729,33 +729,30 @@ class NonSwayColumn2d(Column2d):
 
 
         maximum_applied_axial_load = 0.
-        disp_incr_factor = config['disp_incr_factor']
+        base_incr_factor = config['disp_incr_factor']
+        disp_incr_factor = base_incr_factor
         
         
         while True:
             ok = ops.analyze(1)
+            recovered_div = None
 
             if ok != 0 and config['try_smaller_steps']:
                 for div_factor in [1e1, 1e2, 1e3, 1e4, 1e5, 1e6]:
                     update_dU(disp_incr_factor, div_factor)
                     ok = ops.analyze(1)
-                    if ok == 0 and div_factor in [1e3, 1e4, 1e5, 1e6]:
-                        disp_incr_factor /= 10
-                        break
-                    elif ok == 0:
-                        break
-                    else:
+                    if ok != 0:
                         ok = try_analysis_options()
-                        if ok == 0 and div_factor in [1e3, 1e4, 1e5, 1e6]:
-                            disp_incr_factor /= 10
-                            break
-                        elif ok == 0:
-                            break
+                    if ok == 0:
+                        recovered_div = div_factor
+                        break
 
             if ok != 0 and not config['try_smaller_steps']:
                 ok = try_analysis_options()
 
             if ok == 0 and config['try_smaller_steps']:
+                disp_incr_factor = adapt_step_factor(disp_incr_factor, base_incr_factor,
+                                                     recovered_div)
                 reset_analysis_options(disp_incr_factor)
             elif ok != 0:
                 results.exit_message = 'Analysis Failed'
@@ -1012,29 +1009,26 @@ class NonSwayColumn2d(Column2d):
         ops.analyze(1)
 
         maximum_applied_axial_load = 0.
-        disp_incr_factor = config['disp_incr_factor']
+        base_incr_factor = config['disp_incr_factor']
+        disp_incr_factor = base_incr_factor
         
         while True:
             ok = ops.analyze(1)
-            
+            recovered_div = None
+
             if ok != 0 and config['try_smaller_steps']:
                 for div_factor in [1e1, 1e2, 1e3, 1e4, 1e5, 1e6]:
                     update_dU(disp_incr_factor, div_factor)
                     ok = ops.analyze(1)
-                    if ok == 0 and div_factor in [1e3, 1e4, 1e5, 1e6]:
-                        disp_incr_factor /= 10
-                        break
-                    elif ok == 0:
-                        break
-                    else:
+                    if ok != 0:
                         ok = try_analysis_options()
-                        if ok == 0 and div_factor in [1e3, 1e4, 1e5, 1e6]:
-                            disp_incr_factor /= 10
-                            break
-                        elif ok == 0:
-                            break
+                    if ok == 0:
+                        recovered_div = div_factor
+                        break
 
             if ok == 0 and config['try_smaller_steps']:
+                disp_incr_factor = adapt_step_factor(disp_incr_factor, base_incr_factor,
+                                                     recovered_div)
                 reset_analysis_options(disp_incr_factor)
 
             elif ok != 0:
@@ -1207,32 +1201,29 @@ class NonSwayColumn2d(Column2d):
         record()
         
         maximum_moment = 0
-        disp_incr_factor = config['disp_incr_factor']
+        base_incr_factor = config['disp_incr_factor']
+        disp_incr_factor = base_incr_factor
 
         while True:
             ok = ops.analyze(1)
+            recovered_div = None
 
             if ok != 0 and config['try_smaller_steps']:
                 for div_factor in [1e1, 1e2, 1e3, 1e4, 1e5, 1e6]:
                     update_dU(disp_incr_factor, div_factor)
                     ok = ops.analyze(1)
-                    if ok == 0 and div_factor in [1e3, 1e4, 1e5, 1e6]:
-                        disp_incr_factor /= 10
-                        break
-                    elif ok == 0:
-                        break
-                    else:
+                    if ok != 0:
                         ok = try_analysis_options()
-                        if ok == 0 and div_factor in [1e3, 1e4, 1e5, 1e6]:
-                            disp_incr_factor /= 10
-                            break
-                        elif ok == 0:
-                            break
+                    if ok == 0:
+                        recovered_div = div_factor
+                        break
 
             if ok != 0 and not config['try_smaller_steps']:
                 ok = try_analysis_options()
 
             if ok == 0:
+                disp_incr_factor = adapt_step_factor(disp_incr_factor, base_incr_factor,
+                                                     recovered_div)
                 reset_analysis_options(disp_incr_factor)
             elif ok != 0:
                 results.exit_message = 'Analysis Failed'

--- a/src/libdenavit/non_sway_column_2d.py
+++ b/src/libdenavit/non_sway_column_2d.py
@@ -1870,7 +1870,9 @@ class NonSwayColumn2d(Column2d):
 
                 # Record whatever we got at the limit point
                 P.append(iP)
-                M1.append(results.applied_moment_top_at_limit_point)
+                M1.append(self._aci_first_order_moment(
+                    results.applied_moment_top_at_limit_point,
+                    results.applied_moment_bot_at_limit_point, iP))
                 M2.append(results.maximum_abs_moment_at_limit_point)
                 exit_message.append(results.exit_message)
 

--- a/src/libdenavit/non_sway_column_2d.py
+++ b/src/libdenavit/non_sway_column_2d.py
@@ -75,6 +75,14 @@ class NonSwayColumn2d(Column2d):
         return 15 + 0.03 * h  # mm
 
 
+    def _aci_first_order_moment(self, M_top, M_bot, P):
+        """
+        First-order moment for the ACI 6.2.5.3 1.4 check (M2/M1 <= 1.4).
+        """
+        applied = max(abs(M_top), abs(M_bot))
+        return max(applied, abs(P) * self._aci_minimum_eccentricity)
+
+
     def _apply_aci_minimum_eccentricity(self, et, eb):
         """Raise the dominant end eccentricity to the ACI 318-19 minimum."""
         e_min = self._aci_minimum_eccentricity
@@ -1482,14 +1490,15 @@ class NonSwayColumn2d(Column2d):
                         results.exit_message = 'Eigenvalue Limit Reached'
                         break
                 
-                if max_1_4_Mu_limit is True:
-                    if (e != 0 or (abs(et) > 1e-12 and abs(eb) > 1e-12)) and \
-                       max(abs(results.applied_moment_top[-1] * 1.4), abs(results.applied_moment_bot[-1] * 1.4)) != 0:
-                        if max(abs(results.applied_moment_top[-1] * 1.4),
-                               abs(results.applied_moment_bot[-1] * 1.4)) <= results.maximum_abs_moment[-1]:
-                            results.exit_message = 'max_1_4_Mu_limit_reached'
-                            break
-                
+                # Skipped for axial-only loading, where there is no applied
+                # first-order moment for the ratio to be measured against.
+                if max_1_4_Mu_limit is True and not (e == 0 or (abs(et) < 1e-12 and abs(eb) < 1e-12)):
+                    first_order = self._aci_first_order_moment(
+                        results.applied_moment_top[-1], results.applied_moment_bot[-1], P_check)
+                    if first_order > 0 and 1.4 * first_order <= results.maximum_abs_moment[-1]:
+                        results.exit_message = 'max_1_4_Mu_limit_reached'
+                        break
+
                 # Check deformation
                 if deformation_limit is not None:
                     if results.maximum_abs_disp[-1] > deformation_limit:
@@ -1676,8 +1685,8 @@ class NonSwayColumn2d(Column2d):
                         # Check for 1.4 Mu limit
                         if et == 0 and eb == 0:
                             continue  # Skip for axial-only columns
-                        applied_1_4_Mu = max(abs(results.applied_moment_top[-1] * 1.4),
-                                             abs(results.applied_moment_bot[-1] * 1.4))
+                        applied_1_4_Mu = 1.4 * self._aci_first_order_moment(
+                            results.applied_moment_top[-1], results.applied_moment_bot[-1], P_check)
                         if applied_1_4_Mu > M_check:
                             max_1_4_Mu_armed = True
                         elif max_1_4_Mu_armed:

--- a/src/libdenavit/non_sway_column_2d.py
+++ b/src/libdenavit/non_sway_column_2d.py
@@ -344,7 +344,7 @@ class NonSwayColumn2d(Column2d):
                 iM2_section = id2d.find_x_given_y(iP, 'pos')
                 k = 1  # Effective length factor (always one for this non-sway column)
 
-                iM1_list = [0]
+                trials = []
                 iM2_list = np.arange(0, iM2_section, iM2_section/1000)
                 for iM2 in iM2_list:
                     EIeff = self.section.EIeff(self.axis, EI_type, beta_dns, P=iP, M=iM2, col=self)
@@ -354,10 +354,13 @@ class NonSwayColumn2d(Column2d):
 
                     delta = max(self.Cm / (1 - (iP) / (Pc_factor * Pc)), 1.0)
 
-                    iM1_list.append(iM2 / delta)
+                    if np.isfinite(iM2 / delta):
+                        trials.append((iM2 / delta, iM2))
 
-                iM1 = max(iM1_list)
-                iM2 = iM2_list[iM1_list.index(iM1)-1]
+                if trials:
+                    iM1, iM2 = max(trials, key=lambda trial: trial[0])
+                else:
+                    iM1, iM2 = 0.0, 0.0
             P_list.append(iP)
             M1_list.append(iM1)
             M2_list.append(iM2)

--- a/src/libdenavit/non_sway_column_2d.py
+++ b/src/libdenavit/non_sway_column_2d.py
@@ -14,6 +14,11 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+# EI_type values whose stiffness varies with the applied load, and which
+# therefore cannot be used where a single constant stiffness is required.
+_LOAD_DEPENDENT_EI_TYPES = frozenset(
+    {'aci-c', 'jf-a', 'jf-b', 'proposed_1_1', 'proposed_1_2', 'proposed_2'})
+
 
 class NonSwayColumn2d(Column2d):
     def __init__(self, section, length, et, eb, **kwargs):
@@ -1272,7 +1277,19 @@ class NonSwayColumn2d(Column2d):
                 disp_incr_factor: Displacement increment factor (default 1e-5)
                 eigenvalue_limit: Eigenvalue limit for stability (default 0.0)
                 deformation_limit: Maximum deformation limit (default 0.1*L)
-                
+                EI_type: Name of a load-independent built-in stiffness method
+                    ('aci-a', 'aci-b', 'gross'). Load-dependent methods are
+                    rejected: the elastic member is built once, before loading,
+                    so its stiffness cannot depend on P or M.
+                EI: Custom effective stiffness, constant or callable, passed
+                    through to RC.EIeff. A callable is evaluated once with
+                    P = M = None.
+                EI_kwargs: Extra keyword arguments for a callable EI
+                betadns: Sustained load ratio used by EI_type (default 0.0)
+
+                With neither EI nor EI_type given, the stiffness falls back to
+                0.875*(0.2*Ec*Ig + Es*Isr) for backwards compatibility.
+
         Returns:
             AnalysisResults object with applied loads and second-order moments
         """
@@ -1294,6 +1311,14 @@ class NonSwayColumn2d(Column2d):
         # also applying self.dxo, which would count the same effect twice. Pass
         # include_imperfection=True to model dxo explicitly instead.
         include_imperfection = kwargs.get('include_imperfection', False)
+        # Effective flexural stiffness of the elastic member. The model is built
+        # once with a single Elastic section, so the stiffness must be constant
+        # over the analysis: EI_type is restricted to the load-independent
+        # methods, and a callable EI is evaluated once, before loading.
+        EI_type = kwargs.get('EI_type', None)
+        EI = kwargs.get('EI', None)
+        EI_kwargs = kwargs.get('EI_kwargs', None)
+        betadns = kwargs.get('betadns', 0.0)
         #endregion
 
 
@@ -1309,10 +1334,28 @@ class NonSwayColumn2d(Column2d):
         
         #region Calculate elastic properties per ACI 318-19
         EI_gross = self.section.EIgross(self.axis)
-        # EI_eff = 0.7 * EI_gross
-        EI_eff = 0.875*(0.2 * self.section.Ec * self.section.Ig(self.axis) + self.section.Es * self.section.Isr(self.axis))
-        A = self.section.Ag  
-        E = self.section.Ec  
+        if EI is None and EI_type is None:
+            # Historical default, kept so existing callers are unaffected:
+            # 0.875 times ACI 318-19 (6.6.4.4.4b). Prefer passing EI or EI_type.
+            EI_eff = 0.875 * (0.2 * self.section.Ec * self.section.Ig(self.axis)
+                              + self.section.Es * self.section.Isr(self.axis))
+        else:
+            if isinstance(EI_type, str) and EI_type.strip().lower() in _LOAD_DEPENDENT_EI_TYPES:
+                raise ValueError(
+                    f'EI_type {EI_type!r} depends on the applied load, but this '
+                    f'analysis builds one Elastic section before loading begins '
+                    f'and so needs a constant stiffness. Pass a constant EI, or '
+                    f'a callable EI that does not use P or M.')
+            EI_eff = self.section.EIeff(
+                self.axis, EI_type, betadns, P=None, M=None, col=self,
+                EI=EI, EI_kwargs=EI_kwargs)
+            EI_eff = float(EI_eff)
+            if not np.isfinite(EI_eff) or EI_eff <= 0:
+                raise ValueError(
+                    f'Effective stiffness must be finite and positive '
+                    f'(got {EI_eff!r})')
+        A = self.section.Ag
+        E = self.section.Ec
         I_eff = EI_eff / E
         #endregion
 

--- a/src/libdenavit/non_sway_column_2d.py
+++ b/src/libdenavit/non_sway_column_2d.py
@@ -60,29 +60,26 @@ class NonSwayColumn2d(Column2d):
         self.t_sus = kwargs.get('t_sus', 10000)
 
 
-    def _apply_aci_minimum_eccentricity(self, et, eb):
+    @property
+    def _aci_minimum_eccentricity(self):
         """
-        Apply ACI 318-19 Section 6.6.4.5.4 minimum eccentricity
+        ACI 318-19 Section 6.6.4.5.4 minimum eccentricity.
 
         e_min = 0.6 + 0.03*h  (in.)   /   15 + 0.03*h  (mm)
+
+        h is the section dimension in the direction of bending.
         """
-        # Get section dimension in direction of bending
-        if self.axis == 'x':
-            h = self.section.conc_cross_section.H
-        elif self.axis == 'y':
-            h = self.section.conc_cross_section.B
-        else:
-            # Default to H if axis not specified
-            h = self.section.conc_cross_section.H
-        
-        # Calculate minimum eccentricity (ACI 318-19 Section 6.6.4.5.4)
+        h = self.section.depth(self.axis)
         if self.section.units == 'us':
-            e_min = 0.6 + 0.03 * h  # in.
-        else:  # SI units
-            e_min = 15 + 0.03 * h  # mm
-        
+            return 0.6 + 0.03 * h  # in.
+        return 15 + 0.03 * h  # mm
+
+
+    def _apply_aci_minimum_eccentricity(self, et, eb):
+        """Raise the dominant end eccentricity to the ACI 318-19 minimum."""
+        e_min = self._aci_minimum_eccentricity
         self.e_min = e_min
-        
+
         # Find maximum eccentricity magnitude
         e_max = max(abs(et), abs(eb))
         

--- a/src/libdenavit/non_sway_column_2d.py
+++ b/src/libdenavit/non_sway_column_2d.py
@@ -122,8 +122,13 @@ class NonSwayColumn2d(Column2d):
 
 
     def _ecc_sign(self):
-        dominant_e = self.et if abs(self.et) >= abs(self.eb) else self.eb
-        return int(np.sign(dominant_e))
+        return int(np.sign(max(self.et, self.eb, key=abs)))
+
+
+    @property
+    def _double_curvature(self):
+        """True if the end eccentricities bend the column in double curvature."""
+        return self.et * self.eb < 0
 
 
     def _initialize_results(self):
@@ -603,8 +608,6 @@ class NonSwayColumn2d(Column2d):
         ops.pattern('Plain', 200, 100)
 
         
-        sgn_et = int(np.sign(self.et))
-        sgn_eb = int(np.sign(self.eb))
         ecc_sign = self._ecc_sign()
 
         ops.constraints('Plain')
@@ -624,7 +627,7 @@ class NonSwayColumn2d(Column2d):
             ops.load(self.ops_n_elem, 0, -1, self.et * config['e'] * ecc_sign)
             ops.load(0, 0, 0, -self.eb * config['e'] * ecc_sign)
         
-            if sgn_et != sgn_eb and (sgn_eb != 0 and sgn_et != 0):
+            if self._double_curvature:
                 if max(self.et, self.eb, key=abs) == self.et:
                     dof = 3 * self.ops_n_elem // 4
                 else:
@@ -669,9 +672,7 @@ class NonSwayColumn2d(Column2d):
                       / max(1, config['num_steps_vertical']) / div_factor)
                 ops.integrator('LoadControl', dF)
                 return
-            sgn_et = int(np.sign(self.et))
-            sgn_eb = int(np.sign(self.eb))
-            if sgn_et != sgn_eb and (sgn_eb != 0 and sgn_et != 0):
+            if self._double_curvature:
                 if max(self.et, self.eb, key=abs) == self.et:
                     dof = 3 * self.ops_n_elem // 4
                 else:
@@ -919,9 +920,7 @@ class NonSwayColumn2d(Column2d):
                 ops.integrator('LoadControl', dF)
             else:
                 # bending present: DisplacementControl as before
-                sgn_et = int(np.sign(self.et))
-                sgn_eb = int(np.sign(self.eb))
-                if sgn_et != sgn_eb and (sgn_eb != 0 and sgn_et != 0):
+                if self._double_curvature:
                     dof = 3 * self.ops_n_elem // 4 if abs(self.et) >= abs(self.eb) else 1 * self.ops_n_elem // 4
                     dU = self.length * disp_incr_factor / 2 / div_factor
                     ops.integrator('DisplacementControl', dof, 1, dU)
@@ -1036,9 +1035,7 @@ class NonSwayColumn2d(Column2d):
     def _run_ops_nonproportional_limit_point(self, config, results):
         """Run nonproportional limit point analysis."""
         def update_dU(disp_incr_factor, div_factor=1):
-            sgn_et = int(np.sign(self.et))
-            sgn_eb = int(np.sign(self.eb))
-            if sgn_et != sgn_eb and (sgn_eb != 0 and sgn_et != 0):
+            if self._double_curvature:
                 if max(self.et, self.eb, key=abs) == self.et:
                     dof = 3 * self.ops_n_elem // 4
                 else:
@@ -1124,11 +1121,9 @@ class NonSwayColumn2d(Column2d):
         ops.timeSeries('Linear', 101)
         ops.pattern('Plain', 201, 101)
         
-        sgn_et = int(np.sign(self.et))
-        sgn_eb = int(np.sign(self.eb))
         ecc_sign = self._ecc_sign()
 
-        if sgn_et != sgn_eb and (sgn_eb != 0 and sgn_et != 0):
+        if self._double_curvature:
             if max(self.et, self.eb, key=abs) == self.et:
                 dof = 3 * self.ops_n_elem // 4
             else:
@@ -1329,8 +1324,6 @@ class NonSwayColumn2d(Column2d):
 
         
         #region Determine eccentricity sign
-        sgn_et = int(np.sign(self.et))
-        sgn_eb = int(np.sign(self.eb))
         ecc_sign = self._ecc_sign()
         #endregion
 
@@ -1388,7 +1381,7 @@ class NonSwayColumn2d(Column2d):
                 ops.integrator('LoadControl', dF)
             else:
                 # Determine displacement control node
-                if sgn_et != sgn_eb and (sgn_eb != 0 and sgn_et != 0):
+                if self._double_curvature:
                     if abs(self.et) >= abs(self.eb):
                         control_node = 3 * self.ops_n_elem // 4
                     else:
@@ -1562,7 +1555,7 @@ class NonSwayColumn2d(Column2d):
                     ops.load(0, 0, 0, -self.eb * e * ecc_sign)
                     
                 # Determine control node and apply moments
-                if sgn_et != sgn_eb and (sgn_eb != 0 and sgn_et != 0):
+                if self._double_curvature:
                     if abs(self.et) >= abs(self.eb):
                         control_node = 3 * self.ops_n_elem // 4
                     else:

--- a/src/libdenavit/non_sway_column_2d.py
+++ b/src/libdenavit/non_sway_column_2d.py
@@ -121,14 +121,26 @@ class NonSwayColumn2d(Column2d):
         return p0
 
 
-    def _ecc_sign(self):
-        return int(np.sign(max(self.et, self.eb, key=abs)))
-
-
     @property
-    def _double_curvature(self):
-        """True if the end eccentricities bend the column in double curvature."""
-        return self.et * self.eb < 0
+    def _oriented_ecc(self):
+        """
+        End eccentricities (et, eb) oriented so the dominant one is non-negative.
+
+        All applied end moments are built from these, so the column always bends
+        toward +x -- the direction of the initial imperfection and of the
+        displacement-control DOF. Orienting by the dominant (largest magnitude)
+        eccentricity rather than by et alone is what keeps a nonzero eb from
+        being zeroed out when et == 0.
+
+        Both ends are scaled by the same sign, so magnitudes and relative sign
+        are preserved. Callers read the two cases they need straight off the
+        returned pair:
+
+            et * eb < 0          -> double curvature
+            abs(et) >= abs(eb)   -> the top end dominates
+        """
+        sign = int(np.sign(max(self.et, self.eb, key=abs)))
+        return self.et * sign, self.eb * sign
 
 
     def _initialize_results(self):
@@ -608,7 +620,7 @@ class NonSwayColumn2d(Column2d):
         ops.pattern('Plain', 200, 100)
 
         
-        ecc_sign = self._ecc_sign()
+        et, eb = self._oriented_ecc
 
         ops.constraints('Plain')
         ops.numberer('RCM')
@@ -624,11 +636,11 @@ class NonSwayColumn2d(Column2d):
             ops.load(0, 0, 0, 0.0)                 # no moment
             ops.integrator('LoadControl', dF)
         else:
-            ops.load(self.ops_n_elem, 0, -1, self.et * config['e'] * ecc_sign)
-            ops.load(0, 0, 0, -self.eb * config['e'] * ecc_sign)
+            ops.load(self.ops_n_elem, 0, -1, et * config['e'])
+            ops.load(0, 0, 0, -eb * config['e'])
         
-            if self._double_curvature:
-                if max(self.et, self.eb, key=abs) == self.et:
+            if et * eb < 0:
+                if abs(et) >= abs(eb):
                     dof = 3 * self.ops_n_elem // 4
                 else:
                     dof = 1 * self.ops_n_elem // 4
@@ -646,8 +658,8 @@ class NonSwayColumn2d(Column2d):
             section_strains = ops_get_section_strains(self)
 
             results.applied_axial_load.append(time)
-            results.applied_moment_top.append(self.et * config['e'] * time * ecc_sign)
-            results.applied_moment_bot.append(-self.eb * config['e'] * time * ecc_sign)
+            results.applied_moment_top.append(et * config['e'] * time)
+            results.applied_moment_bot.append(-eb * config['e'] * time)
             results.maximum_abs_moment.append(ops_get_maximum_abs_moment(self))
             results.maximum_abs_disp.append(ops_get_maximum_abs_disp(self))
             results.lowest_eigenvalue.append(ops.eigen('-fullGenLapack', 1)[0])
@@ -672,8 +684,9 @@ class NonSwayColumn2d(Column2d):
                       / max(1, config['num_steps_vertical']) / div_factor)
                 ops.integrator('LoadControl', dF)
                 return
-            if self._double_curvature:
-                if max(self.et, self.eb, key=abs) == self.et:
+            et, eb = self._oriented_ecc
+            if et * eb < 0:
+                if abs(et) >= abs(eb):
                     dof = 3 * self.ops_n_elem // 4
                 else:
                     dof = 1 * self.ops_n_elem // 4
@@ -756,7 +769,7 @@ class NonSwayColumn2d(Column2d):
         # region Determine the sign of the eccentricity
         sgn_et = int(np.sign(self.et))
         sgn_eb = int(np.sign(self.eb))
-        ecc_sign = self._ecc_sign()
+        et, eb = self._oriented_ecc
         # endregion
 
         # region Define recorder
@@ -781,8 +794,8 @@ class NonSwayColumn2d(Column2d):
                 sys.stderr = original_stderr
 
             results.applied_axial_load.append(time + lam)
-            results.applied_moment_top.append(self.et * config['e'] * (time + lam) * ecc_sign)
-            results.applied_moment_bot.append(-self.eb * config['e'] * (time + lam) * ecc_sign)
+            results.applied_moment_top.append(et * config['e'] * (time + lam))
+            results.applied_moment_bot.append(-eb * config['e'] * (time + lam))
             results.maximum_abs_moment.append(ops_get_maximum_abs_moment(self))
             results.maximum_abs_disp.append(ops_get_maximum_abs_disp(self))
             results.lowest_eigenvalue.append(ops.eigen('-fullGenLapack', 1)[0])
@@ -821,8 +834,8 @@ class NonSwayColumn2d(Column2d):
 
         ops.timeSeries('Linear', 100)
         ops.pattern('Plain', 200, 100, '-factor', 1)
-        ops.load(self.ops_n_elem, 0, -1, self.et * config['e'] * ecc_sign)
-        ops.load(0, 0, 0, -self.eb * config['e'] * ecc_sign)
+        ops.load(self.ops_n_elem, 0, -1, et * config['e'])
+        ops.load(0, 0, 0, -eb * config['e'])
         
         while t < tfinish:
             # Apply sustained load at Tcr
@@ -920,8 +933,9 @@ class NonSwayColumn2d(Column2d):
                 ops.integrator('LoadControl', dF)
             else:
                 # bending present: DisplacementControl as before
-                if self._double_curvature:
-                    dof = 3 * self.ops_n_elem // 4 if abs(self.et) >= abs(self.eb) else 1 * self.ops_n_elem // 4
+                et, eb = self._oriented_ecc
+                if et * eb < 0:
+                    dof = 3 * self.ops_n_elem // 4 if abs(et) >= abs(eb) else 1 * self.ops_n_elem // 4
                     dU = self.length * disp_incr_factor / 2 / div_factor
                     ops.integrator('DisplacementControl', dof, 1, dU)
                 else:
@@ -951,18 +965,18 @@ class NonSwayColumn2d(Column2d):
             ops.load(0, 0, 0, 0)
             ops.integrator('LoadControl', dF)
         elif sgn_et != sgn_eb:
-            if max(self.et, self.eb, key=abs) == self.et:
+            if abs(et) >= abs(eb):
                 dof = 3 * self.ops_n_elem // 4
             else:
                 dof = 1 * self.ops_n_elem // 4
             dU = self.length * config['disp_incr_factor'] / 20
-            ops.load(self.ops_n_elem, 0, -1, self.et * config['e'] * ecc_sign)
-            ops.load(0, 0, 0, -self.eb * config['e'] * ecc_sign)
+            ops.load(self.ops_n_elem, 0, -1, et * config['e'])
+            ops.load(0, 0, 0, -eb * config['e'])
             ops.integrator('DisplacementControl', dof, 1, dU)
         else:
             dU = self.length * config['disp_incr_factor'] / 10
-            ops.load(self.ops_n_elem, 0, -1, self.et * config['e'] * ecc_sign)
-            ops.load(0, 0, 0, -self.eb * config['e'] * ecc_sign)
+            ops.load(self.ops_n_elem, 0, -1, et * config['e'])
+            ops.load(0, 0, 0, -eb * config['e'])
             ops.integrator('DisplacementControl', self.ops_mid_node, 1, dU)
 
         ops.constraints('Plain')
@@ -1035,8 +1049,9 @@ class NonSwayColumn2d(Column2d):
     def _run_ops_nonproportional_limit_point(self, config, results):
         """Run nonproportional limit point analysis."""
         def update_dU(disp_incr_factor, div_factor=1):
-            if self._double_curvature:
-                if max(self.et, self.eb, key=abs) == self.et:
+            et, eb = self._oriented_ecc
+            if et * eb < 0:
+                if abs(et) >= abs(eb):
                     dof = 3 * self.ops_n_elem // 4
                 else:
                     dof = 1 * self.ops_n_elem // 4
@@ -1121,21 +1136,21 @@ class NonSwayColumn2d(Column2d):
         ops.timeSeries('Linear', 101)
         ops.pattern('Plain', 201, 101)
         
-        ecc_sign = self._ecc_sign()
+        et, eb = self._oriented_ecc
 
-        if self._double_curvature:
-            if max(self.et, self.eb, key=abs) == self.et:
+        if et * eb < 0:
+            if abs(et) >= abs(eb):
                 dof = 3 * self.ops_n_elem // 4
             else:
                 dof = 1 * self.ops_n_elem // 4
             dU = self.length * config['disp_incr_factor'] / 2
-            ops.load(self.ops_n_elem, 0, 0, self.et * config['e'] * ecc_sign)
-            ops.load(0, 0, 0, -self.eb * config['e'] * ecc_sign)
+            ops.load(self.ops_n_elem, 0, 0, et * config['e'])
+            ops.load(0, 0, 0, -eb * config['e'])
             ops.integrator('DisplacementControl', dof, 1, dU)
         else:
             dU = self.length * config['disp_incr_factor']
-            ops.load(self.ops_n_elem, 0, 0, self.et * config['e'] * ecc_sign)
-            ops.load(0, 0, 0, -self.eb * config['e'] * ecc_sign)
+            ops.load(self.ops_n_elem, 0, 0, et * config['e'])
+            ops.load(0, 0, 0, -eb * config['e'])
             ops.integrator('DisplacementControl', self.ops_mid_node, 1, dU)
         
         ops.analysis('Static', '-noWarnings')
@@ -1146,8 +1161,8 @@ class NonSwayColumn2d(Column2d):
             section_strains = ops_get_section_strains(self)
 
             results.applied_axial_load.append(config['P'])
-            results.applied_moment_top.append(self.et * config['e'] * time * ecc_sign)
-            results.applied_moment_bot.append(-self.eb * config['e'] * time * ecc_sign)
+            results.applied_moment_top.append(et * config['e'] * time)
+            results.applied_moment_bot.append(-eb * config['e'] * time)
             results.maximum_abs_moment.append(ops_get_maximum_abs_moment(self))
             results.maximum_abs_disp.append(ops_get_maximum_abs_disp(self))
             results.lowest_eigenvalue.append(ops.eigen('-fullGenLapack', 1)[0])
@@ -1324,7 +1339,7 @@ class NonSwayColumn2d(Column2d):
 
         
         #region Determine eccentricity sign
-        ecc_sign = self._ecc_sign()
+        et, eb = self._oriented_ecc
         #endregion
 
         
@@ -1366,8 +1381,8 @@ class NonSwayColumn2d(Column2d):
             ops.pattern('Plain', 200, 100)
             
             # Applied loads proportional to load factor (time)
-            ops.load(self.ops_n_elem, 0, -1, self.et * e * ecc_sign)
-            ops.load(0, 0, 0, -self.eb * e * ecc_sign)
+            ops.load(self.ops_n_elem, 0, -1, et * e)
+            ops.load(0, 0, 0, -eb * e)
             
             ops.constraints('Plain')
             ops.numberer('RCM')
@@ -1376,13 +1391,13 @@ class NonSwayColumn2d(Column2d):
             ops.algorithm('Newton')
             
             # Determine displacement control node
-            if e == 0.0 or (abs(self.et) < 1e-12 and abs(self.eb) < 1e-12):
+            if e == 0.0 or (abs(et) < 1e-12 and abs(eb) < 1e-12):
                 dF = 1/num_steps_vertical
                 ops.integrator('LoadControl', dF)
             else:
                 # Determine displacement control node
-                if self._double_curvature:
-                    if abs(self.et) >= abs(self.eb):
+                if et * eb < 0:
+                    if abs(et) >= abs(eb):
                         control_node = 3 * self.ops_n_elem // 4
                     else:
                         control_node = 1 * self.ops_n_elem // 4
@@ -1399,8 +1414,8 @@ class NonSwayColumn2d(Column2d):
             def record_prop():
                 time = ops.getTime()
                 results.applied_axial_load.append(time)
-                results.applied_moment_top.append(self.et * e * time * ecc_sign)
-                results.applied_moment_bot.append(-self.eb * e * time * ecc_sign)
+                results.applied_moment_top.append(et * e * time)
+                results.applied_moment_bot.append(-eb * e * time)
                 record()
             
             record_prop()
@@ -1471,7 +1486,7 @@ class NonSwayColumn2d(Column2d):
                         break
                 
                 if max_1_4_Mu_limit is True:
-                    if (e != 0 or (abs(self.et) > 1e-12 and abs(self.eb) > 1e-12)) and \
+                    if (e != 0 or (abs(et) > 1e-12 and abs(eb) > 1e-12)) and \
                        max(abs(results.applied_moment_top[-1] * 1.4), abs(results.applied_moment_bot[-1] * 1.4)) != 0:
                         if max(abs(results.applied_moment_top[-1] * 1.4),
                                abs(results.applied_moment_bot[-1] * 1.4)) <= results.maximum_abs_moment[-1]:
@@ -1543,7 +1558,7 @@ class NonSwayColumn2d(Column2d):
                 time_offset = ops.getTime() 
                 
                 # Check if axial-only column
-                is_axial_only = abs(self.et) < 1e-10 and abs(self.eb) < 1e-10
+                is_axial_only = abs(et) < 1e-10 and abs(eb) < 1e-10
                 
                 if is_axial_only:
                     # Apply unit moments for axial-only columns
@@ -1551,12 +1566,12 @@ class NonSwayColumn2d(Column2d):
                     ops.load(0, 0, 0, -1.0)
                 else:
                     # Normal columns with eccentricity
-                    ops.load(self.ops_n_elem, 0, 0, self.et * e * ecc_sign)
-                    ops.load(0, 0, 0, -self.eb * e * ecc_sign)
+                    ops.load(self.ops_n_elem, 0, 0, et * e)
+                    ops.load(0, 0, 0, -eb * e)
                     
                 # Determine control node and apply moments
-                if self._double_curvature:
-                    if abs(self.et) >= abs(self.eb):
+                if et * eb < 0:
+                    if abs(et) >= abs(eb):
                         control_node = 3 * self.ops_n_elem // 4
                     else:
                         control_node = 1 * self.ops_n_elem // 4
@@ -1580,8 +1595,8 @@ class NonSwayColumn2d(Column2d):
                         results.applied_moment_bot.append(-time)
                     else:
                         # Normal columns
-                        results.applied_moment_top.append(self.et * e * time * ecc_sign)
-                        results.applied_moment_bot.append(-self.eb * e * time * ecc_sign)
+                        results.applied_moment_top.append(et * e * time)
+                        results.applied_moment_bot.append(-eb * e * time)
                     record()
                 
                 record_stage2()
@@ -1662,7 +1677,7 @@ class NonSwayColumn2d(Column2d):
                     
                     if max_1_4_Mu_limit:
                         # Check for 1.4 Mu limit
-                        if self.et == 0 and self.eb == 0:
+                        if et == 0 and eb == 0:
                             continue  # Skip for axial-only columns
                         applied_1_4_Mu = max(abs(results.applied_moment_top[-1] * 1.4),
                                              abs(results.applied_moment_bot[-1] * 1.4))
@@ -1685,7 +1700,7 @@ class NonSwayColumn2d(Column2d):
         logger.debug(f'Applied bottom moments: {results.applied_moment_bot}')
         logger.debug(f'Maximum absolute moments: {results.maximum_abs_moment}')
         logger.debug(f'Maximum absolute displacements: {results.maximum_abs_disp}')
-        logger.debug(f'et: {self.et}, eb: {self.eb}, e: {e}, ecc_sign: {ecc_sign}')
+        logger.debug(f'et: {self.et}, eb: {self.eb}, e: {e}, oriented: {(et, eb)}')
         
         
         #region Find limit point
@@ -1716,7 +1731,7 @@ class NonSwayColumn2d(Column2d):
                 M_check_result = section_interaction.find_x_given_y(P_check, 'pos')
                 M_check = M_check_result[0] if isinstance(M_check_result, list) else M_check_result
             except Exception as exc:
-                if e==0 or (abs(self.et) < 1e-12 and abs(self.eb) < 1e-12):
+                if e==0 or (abs(et) < 1e-12 and abs(eb) < 1e-12):
                     logger.debug(f'find_x_given_y failed for axial-only case, defaulting M_check to 0: {exc}')
                     M_check = 0.0
                 else:

--- a/src/libdenavit/non_sway_column_2d.py
+++ b/src/libdenavit/non_sway_column_2d.py
@@ -1773,6 +1773,7 @@ class NonSwayColumn2d(Column2d):
             'proportional_limit_point',
             e=0,
             section_id=section_id,
+            section_factored=section_factored,
             disp_incr_factor=prop_disp_incr_factor)
 
         P_cr_elastic = results_pcr.applied_axial_load_at_limit_point
@@ -1822,6 +1823,7 @@ class NonSwayColumn2d(Column2d):
                     P=iP,
                     e=e,
                     section_id=section_id,
+                    section_factored=section_factored,
                     disp_incr_factor=nonprop_disp_incr_factor
                 )
 

--- a/src/libdenavit/non_sway_column_2d.py
+++ b/src/libdenavit/non_sway_column_2d.py
@@ -80,6 +80,9 @@ class NonSwayColumn2d(Column2d):
         First-order moment for the ACI 6.2.5.3 1.4 check (M2/M1 <= 1.4).
 
         Pass apply_minimum=False to use the raw applied moment instead.
+
+        Independent of apply_minimum_eccentricity, which changes the loading
+        itself; this only changes what M1 is measured against.
         """
         applied = max(abs(M_top), abs(M_bot))
         if not apply_minimum:
@@ -88,20 +91,23 @@ class NonSwayColumn2d(Column2d):
 
 
     def _apply_aci_minimum_eccentricity(self, et, eb):
-        """Raise the dominant end eccentricity to the ACI 318-19 minimum."""
-        e_min = self._aci_minimum_eccentricity
-        self.e_min = e_min
+        """
+        Raise the dominant end eccentricity to the ACI 318-19 minimum.
 
-        # Find maximum eccentricity magnitude
+        Applied once at construction when apply_minimum_eccentricity is set, so
+        it changes the loading seen by every analysis. Independent of the
+        apply_minimum_moment option of the ACI elastic analyses, which is a
+        checking and reporting basis only. See _aci_first_order_moment.
+        """
+        e_min = self._aci_minimum_eccentricity
         e_max = max(abs(et), abs(eb))
-        
-        # Apply minimum if needed
+
         if e_max < e_min:
             if abs(et) >= abs(eb):
                 et = e_min if et >= 0 else -e_min
             else:
                 eb = e_min if eb >= 0 else -e_min
-        
+
         return et, eb
 
 

--- a/src/libdenavit/non_sway_column_2d.py
+++ b/src/libdenavit/non_sway_column_2d.py
@@ -1277,6 +1277,12 @@ class NonSwayColumn2d(Column2d):
         deformation_limit = kwargs.get('deformation_limit', 0.1 * self.length)
         max_1_4_Mu_limit = kwargs.get('max_1_4_Mu_limit', True)
         section_factored = kwargs.get('section_factored', False)
+        # ACI 318-19 (6.6.4.5.4) covers member out-of-straightness through the
+        # minimum moment Mmin = Pu*(0.6 + 0.03h). This routine emulates the code
+        # procedure, so it builds the column straight by default rather than
+        # also applying self.dxo, which would count the same effect twice. Pass
+        # include_imperfection=True to model dxo explicitly instead.
+        include_imperfection = kwargs.get('include_imperfection', False)
         #endregion
 
 
@@ -1304,12 +1310,12 @@ class NonSwayColumn2d(Column2d):
         ops.wipe()
         ops.model('basic', '-ndm', 2, '-ndf', 3)
         
-        # Create nodes with imperfection if specified
+        # Create nodes, straight unless an explicit imperfection is requested
         for i in range(self.ops_n_elem + 1):
-            if isinstance(self.dxo, (int, float)):
-                x = sin(i / self.ops_n_elem * pi) * self.dxo
-            elif self.dxo is None:
+            if not include_imperfection or self.dxo is None:
                 x = 0.0
+            elif isinstance(self.dxo, (int, float)):
+                x = sin(i / self.ops_n_elem * pi) * self.dxo
             else:
                 raise ValueError(f'Unknown value of dxo ({self.dxo})')
             y = i / self.ops_n_elem * self.length

--- a/src/libdenavit/non_sway_column_2d.py
+++ b/src/libdenavit/non_sway_column_2d.py
@@ -1563,8 +1563,11 @@ class NonSwayColumn2d(Column2d):
                         results.exit_message = 'Eigenvalue Limit Reached'
                         break
                 
-                # Skipped for axial-only loading, where there is no applied
-                # first-order moment for the ratio to be measured against.
+                # ACI 6.2.5.3: flag a column whose second-order moment has
+                # amplified past 1.4x its first-order moment. Skipped for
+                # axial-only loading, where there is no first-order moment to
+                # measure against. See _aci_first_order_moment for why M1 is
+                # floored at Mmin.
                 if max_1_4_Mu_limit is True and not (e == 0 or (abs(et) < 1e-12 and abs(eb) < 1e-12)):
                     first_order = self._aci_first_order_moment(
                         results.applied_moment_top[-1], results.applied_moment_bot[-1], P_check,
@@ -1756,7 +1759,9 @@ class NonSwayColumn2d(Column2d):
                             break
                     
                     if max_1_4_Mu_limit:
-                        # Check for 1.4 Mu limit
+                        # ACI 6.2.5.3: flag a column whose second-order moment
+                        # has amplified past 1.4x its first-order moment. See
+                        # _aci_first_order_moment for why M1 is floored at Mmin.
                         if et == 0 and eb == 0:
                             continue  # Skip for axial-only columns
                         applied_1_4_Mu = 1.4 * self._aci_first_order_moment(

--- a/src/libdenavit/non_sway_column_2d.py
+++ b/src/libdenavit/non_sway_column_2d.py
@@ -63,7 +63,8 @@ class NonSwayColumn2d(Column2d):
     def _apply_aci_minimum_eccentricity(self, et, eb):
         """
         Apply ACI 318-19 Section 6.6.4.5.4 minimum eccentricity
-        e_min = max(0.6 + 0.03*h, 1.0 inch)
+
+        e_min = 0.6 + 0.03*h  (in.)   /   15 + 0.03*h  (mm)
         """
         # Get section dimension in direction of bending
         if self.axis == 'x':
@@ -76,9 +77,9 @@ class NonSwayColumn2d(Column2d):
         
         # Calculate minimum eccentricity (ACI 318-19 Section 6.6.4.5.4)
         if self.section.units == 'us':
-            e_min = 0.6 + 0.03 * h
+            e_min = 0.6 + 0.03 * h  # in.
         else:  # SI units
-            e_min = max(15 + 0.03 * h, 25)  # in mm
+            e_min = 15 + 0.03 * h  # mm
         
         self.e_min = e_min
         

--- a/src/libdenavit/non_sway_column_2d.py
+++ b/src/libdenavit/non_sway_column_2d.py
@@ -1829,7 +1829,6 @@ class NonSwayColumn2d(Column2d):
         # 2. Get Material P-M Diagram (for P_max_material and M_n_material)
         P_sect, M_sect, _ = self.section.section_interaction_2d(self.axis, 100, factored=section_factored,
                                                                 only_compressive=True)
-        section_interaction = InteractionDiagram2d(M_sect, P_sect, is_closed=False)
         P_max_material = np.max(P_sect)
 
         # Find pure bending strength (Mn)
@@ -1845,7 +1844,7 @@ class NonSwayColumn2d(Column2d):
         # Initialize results list with the first point (axial-only loading)
         P = [P_start]
         M1 = [0]
-        M2 = [section_interaction.find_x_given_y(P_start, 'pos')]
+        M2 = [results_pcr.maximum_abs_moment_at_limit_point]
         exit_message = [results_pcr.exit_message]
 
         if np.isnan(P[0]):

--- a/src/libdenavit/non_sway_column_2d.py
+++ b/src/libdenavit/non_sway_column_2d.py
@@ -21,6 +21,10 @@ _LOAD_DEPENDENT_EI_TYPES = frozenset(
 
 
 class NonSwayColumn2d(Column2d):
+
+    _INIT_KWARGS = Column2d._INIT_KWARGS | {
+        'apply_minimum_eccentricity', 'creep', 'P_sus', 't_sus',
+    }
     def __init__(self, section, length, et, eb, **kwargs):
         """
             Represents a non-sway 2D column
@@ -37,8 +41,8 @@ class NonSwayColumn2d(Column2d):
                           dxo (float or None, optional): Initial geometric imperfection.
                                                          Default is 0.0. If None, then no imperfection is included.
                           axis (str, optional): Axis. Default is None.
-                          n_elem (int, optional): Number of elements for OpenSees analysis. Default is 6.
-                          element_type (str, optional): Type of OpenSees element. Default is 'mixedBeamColumn'.
+                          ops_n_elem (int, optional): Number of elements for OpenSees analysis. Default is 8.
+                          ops_element_type (str, optional): Type of OpenSees element. Default is 'mixedBeamColumn'.
                           ops_geom_transf_type (str, optional): OpenSees geometric transformation type. Default is 'Corotational'.
                           ops_integration_points (int, optional): Number of integration points for OpenSees analysis. Default is 3.
         """

--- a/src/libdenavit/non_sway_column_2d.py
+++ b/src/libdenavit/non_sway_column_2d.py
@@ -1671,14 +1671,13 @@ class NonSwayColumn2d(Column2d):
                 
                 record_stage2()
                 
-                # The 1.4Mu limit marks where the second-order moment grows to
-                # 1.4x the applied first-order moment. At the start of the
-                # lateral stage the applied moment is still zero while the
-                # second-order moment already carries P*delta from the axial
-                # stage, so the ratio starts above 1.4 and the test would trip
-                # on the first step. Only arm it once the ratio has come down
-                # below 1.4, and report the crossing on the way back up.
-                max_1_4_Mu_armed = False
+                # M2/M1 is not monotonic over this stage. The applied moment
+                # starts at zero while M2 already carries P*delta from the
+                # axial stage, so the ratio starts arbitrarily large, falls as
+                # the applied moment grows, then rises again toward failure.
+                # The ACI 6.2.5.3 limit is the crossing on the way back up, so
+                # ignore the ratio until it has been below 1.4 at least once.
+                ratio_has_been_below_limit = False
 
                 # MODIFIED: Run lateral loading with more permissive limits
                 max_moment = 0.0
@@ -1746,15 +1745,16 @@ class NonSwayColumn2d(Column2d):
                             break
                     
                     if max_1_4_Mu_limit:
-                        # ACI 6.2.5.3: flag a column whose second-order moment
-                        # has amplified past 1.4x its first-order moment.
+                        # ACI 6.2.5.3: the second-order moment must not exceed
+                        # 1.4x the first-order moment.
                         if et == 0 and eb == 0:
-                            continue  # Skip for axial-only columns
-                        applied_1_4_Mu = 1.4 * self._applied_first_order_moment(
+                            continue  # no applied moment to measure against
+                        applied_M1 = self._applied_first_order_moment(
                             results.applied_moment_top[-1], results.applied_moment_bot[-1])
-                        if applied_1_4_Mu > M_check:
-                            max_1_4_Mu_armed = True
-                        elif max_1_4_Mu_armed:
+                        over_limit = M_check >= 1.4 * applied_M1
+                        if not over_limit:
+                            ratio_has_been_below_limit = True
+                        elif ratio_has_been_below_limit:
                             results.exit_message = 'max_1_4_Mu_limit_reached'
                             break
                     

--- a/src/libdenavit/non_sway_column_2d.py
+++ b/src/libdenavit/non_sway_column_2d.py
@@ -101,6 +101,26 @@ class NonSwayColumn2d(Column2d):
         return 0.1 * self.length
 
 
+    def _reference_axial_load(self):
+        """
+        Reference axial load used to size load-control increments.
+
+        num_steps_vertical is the number of steps taken to reach the reference
+        load, so the increment has to be on the scale of the column's axial
+        capacity. Using a unit reference makes an axial-only analysis take
+        (capacity / num_steps_vertical) times more steps than intended.
+
+        Falls back to a unit reference for sections that define no squash load.
+        """
+        try:
+            p0 = float(self.section.p0)
+        except (AttributeError, TypeError, ValueError):
+            return 1.0
+        if not np.isfinite(p0) or p0 <= 0:
+            return 1.0
+        return p0
+
+
     def _ecc_sign(self):
         dominant_e = self.et if abs(self.et) >= abs(self.eb) else self.eb
         return int(np.sign(dominant_e))
@@ -596,7 +616,7 @@ class NonSwayColumn2d(Column2d):
 
         if config['e'] == 0.0:
             # axial-only: vertical load only, no moments
-            dF = 1 / max(1, config['num_steps_vertical'])
+            dF = self._reference_axial_load() / max(1, config['num_steps_vertical'])
             ops.load(self.ops_n_elem, 0, -1, 0)  # reference vertical load
             ops.load(0, 0, 0, 0.0)                 # no moment
             ops.integrator('LoadControl', dF)
@@ -645,7 +665,8 @@ class NonSwayColumn2d(Column2d):
         def update_dU(disp_incr_factor, div_factor=1):
             if config['e'] == 0.0:
                 # axial-only: shrink the load step, stay in LoadControl
-                dF = (1.0 / max(1, config['num_steps_vertical'])) / div_factor
+                dF = (self._reference_axial_load()
+                      / max(1, config['num_steps_vertical']) / div_factor)
                 ops.integrator('LoadControl', dF)
                 return
             sgn_et = int(np.sign(self.et))

--- a/src/libdenavit/non_sway_column_2d.py
+++ b/src/libdenavit/non_sway_column_2d.py
@@ -422,7 +422,7 @@ class NonSwayColumn2d(Column2d):
                 continue
 
             delta = M2 / M1
-            if self.Cm / delta == 1:
+            if np.isclose(self.Cm / delta, 1.0):
                 # e.g. the pure-bending point (P=0, M1==M2==delta==1) combined with Cm==1
                 # (uniform moment / single curvature): the moment-magnification denominator
                 # (1 - Cm/delta) is exactly zero, so Pc is undefined here.
@@ -478,7 +478,7 @@ class NonSwayColumn2d(Column2d):
                 continue
 
             delta = M2 / M1
-            if self.Cm / delta == 1:
+            if np.isclose(self.Cm / delta, 1.0):
                 # e.g. the pure-bending point (P=0, M1==M2==delta==1) combined with Cm==1
                 # (uniform moment / single curvature): the moment-magnification denominator
                 # (1 - Cm/delta) is exactly zero, so Pc is undefined here.

--- a/src/libdenavit/non_sway_column_2d.py
+++ b/src/libdenavit/non_sway_column_2d.py
@@ -1513,14 +1513,7 @@ class NonSwayColumn2d(Column2d):
                 
                 # Check if P exceeds material capacity
                 P_check = results.applied_axial_load[-1]
-                
-                if max_1_4_Mu_limit is True:
-                    if max(abs(results.applied_moment_top[-1] * 1.4),
-                        abs(results.applied_moment_bot[-1] * 1.4)) <= results.maximum_abs_moment[-1]:
-                        if e!= 0 or (abs(self.et) > 1e-12 and abs(self.eb) > 1e-12):
-                            results.exit_message = 'max_1_4_Mu_limit_reached'
-                            break
-                
+
                 if P_check > P_max_material:
                     results.exit_message = 'Material Strength Limit Reached'
                     break
@@ -1578,6 +1571,15 @@ class NonSwayColumn2d(Column2d):
                 
                 record_stage2()
                 
+                # The 1.4Mu limit marks where the second-order moment grows to
+                # 1.4x the applied first-order moment. At the start of the
+                # lateral stage the applied moment is still zero while the
+                # second-order moment already carries P*delta from the axial
+                # stage, so the ratio starts above 1.4 and the test would trip
+                # on the first step. Only arm it once the ratio has come down
+                # below 1.4, and report the crossing on the way back up.
+                max_1_4_Mu_armed = False
+
                 # MODIFIED: Run lateral loading with more permissive limits
                 max_moment = 0.0
                 max_steps = 10000000  # Prevent infinite loops
@@ -1644,11 +1646,14 @@ class NonSwayColumn2d(Column2d):
                             break
                     
                     if max_1_4_Mu_limit:
-                        # Check for 1/4 Mu limit
+                        # Check for 1.4 Mu limit
                         if self.et == 0 and self.eb == 0:
                             continue  # Skip for axial-only columns
-                        if max(abs(results.applied_moment_top[-1] * 1.4),
-                               abs(results.applied_moment_bot[-1] * 1.4)) <= M_check:
+                        applied_1_4_Mu = max(abs(results.applied_moment_top[-1] * 1.4),
+                                             abs(results.applied_moment_bot[-1] * 1.4))
+                        if applied_1_4_Mu > M_check:
+                            max_1_4_Mu_armed = True
+                        elif max_1_4_Mu_armed:
                             results.exit_message = 'max_1_4_Mu_limit_reached'
                             break
                     

--- a/src/libdenavit/non_sway_column_2d.py
+++ b/src/libdenavit/non_sway_column_2d.py
@@ -655,10 +655,14 @@ class NonSwayColumn2d(Column2d):
 
         if config['e'] == 0.0:
             # axial-only: vertical load only, no moments
-            dF = self._reference_axial_load() / max(1, config['num_steps_vertical'])
             ops.load(self.ops_n_elem, 0, -1, 0)  # reference vertical load
             ops.load(0, 0, 0, 0.0)                 # no moment
-            ops.integrator('LoadControl', dF)
+            if config['axial_control'] == 'displacement':
+                ops.integrator('DisplacementControl', self.ops_n_elem, 2,
+                               -self.length * config['disp_incr_factor'])
+            else:
+                dF = self._reference_axial_load() / max(1, config['num_steps_vertical'])
+                ops.integrator('LoadControl', dF)
         else:
             ops.load(self.ops_n_elem, 0, -1, et * config['e'])
             ops.load(0, 0, 0, -eb * config['e'])
@@ -702,10 +706,18 @@ class NonSwayColumn2d(Column2d):
                 raise ValueError(f'The value of axis ({self.axis}) is not supported.')
 
         def update_dU(disp_incr_factor, div_factor=1):
+            base_incr_factor = config['disp_incr_factor']
+            step_scale = disp_incr_factor / base_incr_factor if base_incr_factor else 1.0
+
             if config['e'] == 0.0:
+                if config['axial_control'] == 'displacement':
+                    dU = -self.length * disp_incr_factor / div_factor
+                    ops.integrator('DisplacementControl', self.ops_n_elem, 2, dU)
+                    return
                 # axial-only: shrink the load step, stay in LoadControl
                 dF = (self._reference_axial_load()
-                      / max(1, config['num_steps_vertical']) / div_factor)
+                      / max(1, config['num_steps_vertical'])
+                      * step_scale / div_factor)
                 ops.integrator('LoadControl', dF)
                 return
             et, eb = self._oriented_ecc
@@ -948,9 +960,12 @@ class NonSwayColumn2d(Column2d):
 
 
         def update_dU(disp_incr_factor, div_factor=1):
+            base_incr_factor = config['disp_incr_factor']
+            step_scale = disp_incr_factor / base_incr_factor if base_incr_factor else 1.0
+
             if config['e'] == 0.0:
                 # axial-only: shrink load step, stay in LoadControl
-                dF = (1.0 / max(1, config['num_steps_vertical'])) / div_factor
+                dF = (1.0 / max(1, config['num_steps_vertical'])) * step_scale / div_factor
                 ops.integrator('LoadControl', dF)
             else:
                 # bending present: DisplacementControl as before

--- a/src/libdenavit/non_sway_column_2d.py
+++ b/src/libdenavit/non_sway_column_2d.py
@@ -1458,9 +1458,9 @@ class NonSwayColumn2d(Column2d):
                         if M_check > M_boundary:
                             results.exit_message = 'Material Strength Limit Reached'
                             break
-                    except Exception as e:
+                    except Exception as exc:
                         # If find_x_given_y fails, the point is outside the valid range
-                        logger.debug(f'find_x_given_y failed, treating point as outside the valid range: {e}')
+                        logger.debug(f'find_x_given_y failed, treating point as outside the valid range: {exc}')
                         results.exit_message = 'Material Strength Limit Reached'
                         break
 
@@ -1642,9 +1642,9 @@ class NonSwayColumn2d(Column2d):
                             if M_check > M_boundary:
                                 results.exit_message = 'Material Strength Limit Reached'
                                 break
-                        except Exception as e:
+                        except Exception as exc:
                             # If find_x_given_y fails, the point is outside the valid range
-                            logger.debug(f'find_x_given_y failed, treating point as outside the valid range: {e}')
+                            logger.debug(f'find_x_given_y failed, treating point as outside the valid range: {exc}')
                             results.exit_message = 'Material Strength Limit Reached'
                             break
                     

--- a/src/libdenavit/non_sway_column_2d.py
+++ b/src/libdenavit/non_sway_column_2d.py
@@ -413,9 +413,9 @@ class NonSwayColumn2d(Column2d):
                     EIeff = self.section.EIeff(self.axis, EI_type, beta_dns, P=iP, M=iM1_trial, col=self)
                     Pc = pi ** 2 * EIeff / (k * self.length) ** 2
                     if Pc_factor * Pc <= iP:
-                        # Unstable at this first-order moment; a larger moment
-                        # only softens the section further, so stop here.
-                        break
+                        # No valid magnifier at this first-order moment. Skip rather
+                        # than stop, since a custom EI need not fall monotonically with M.
+                        continue
 
                     delta = max(self.Cm / (1 - (iP) / (Pc_factor * Pc)), 1.0)
                     iM2_trial = delta * iM1_trial

--- a/src/libdenavit/section/RC.py
+++ b/src/libdenavit/section/RC.py
@@ -686,7 +686,7 @@ class RC:
             P_arr, M_arr, scalar_input = self._as_load_arrays(EI_type, P, M)
             ecc_ratio = self._eccentricity_ratio(P_arr, M_arr, self.depth(axis))
             shape_factor = np.where(ecc_ratio <= 0.1, 1.0, 1.2 - 2 * ecc_ratio)
-            EI_jenkins = ((1.0 - 0.5 * P_arr / self.p0)
+            EI_jenkins = ((1.0 - 0.5 * np.abs(P_arr) / self.p0g)
                           * Ec * Ig * shape_factor / creep_factor)
             min_EI = 0.4 * Ec * Ig / creep_factor
             return self._match_load_shape(np.maximum(EI_jenkins, min_EI), scalar_input)

--- a/src/libdenavit/section/RC.py
+++ b/src/libdenavit/section/RC.py
@@ -920,6 +920,10 @@ class RC:
             Optional argument to include creep parameters in concrete definition
         """
 
+        for _name, _value in (('nfy', nfy), ('nfx', nfx)):
+            if not isinstance(_value, (int, np.integer)) or isinstance(_value, bool) or _value < 1:
+                raise ValueError(f'{_name} must be a positive integer (got {_value!r})')
+
         # region Define Material IDs
         steel_material_id = start_material_id
         concrete_material_id = start_material_id + 1  # Used if no confinement
@@ -1138,22 +1142,22 @@ class RC:
                 cdb = (H - reinf_depth) / 2 - self.reinforcement[0].db / 2
                 if self.dbt is not None:
                     cdb = cdb - self.dbt / 2
+                def strip_layer(material_id, n_fibers, y_start, y_end):
+                    n_fibers = max(1, int(n_fibers))
+                    strip_height = (y_end - y_start) / n_fibers
+                    half = strip_height / 2
+                    ops.layer('straight', material_id, n_fibers, strip_height * B,
+                              y_start + half, 0, y_end - half, 0)
+
                 if confinement:
-                    nfd_cover = ceil(cdb * nfd / H)
-                    nfd_core = ceil((H - 2 * cdb) * nfd / H)
+                    nfd_cover = max(1, ceil(cdb * nfd / H))
+                    nfd_core = max(1, ceil((H - 2 * cdb) * nfd / H))
 
-                    core_fiber_height = (H - 2 * cdb) / nfd_core
-                    cover_fiber_height = cdb / nfd_cover
-
-                    ops.layer('straight', core_concrete_material_id, nfd_core, core_fiber_height * B,
-                              -H / 2 + cdb, 0, H / 2 - cdb, 0)
-                    ops.layer('straight', cover_concrete_material_id, nfd_cover, cover_fiber_height * B,
-                              -H / 2, 0, -H / 2 + cdb, 0)
-                    ops.layer('straight', cover_concrete_material_id, nfd_cover, cover_fiber_height * B,
-                              H / 2 - cdb, 0, H / 2, 0)
+                    strip_layer(core_concrete_material_id, nfd_core, -H / 2 + cdb, H / 2 - cdb)
+                    strip_layer(cover_concrete_material_id, nfd_cover, -H / 2, -H / 2 + cdb)
+                    strip_layer(cover_concrete_material_id, nfd_cover, H / 2 - cdb, H / 2)
                 else:
-                    fiber_height = H / nfd
-                    ops.layer('straight', concrete_material_id, nfd, fiber_height * B, -H / 2, 0, H / 2, 0)
+                    strip_layer(concrete_material_id, nfd, -H / 2, H / 2)
 
             else:
                 raise ValueError(f'Unknown option for axis: {axis}')

--- a/src/libdenavit/section/RC.py
+++ b/src/libdenavit/section/RC.py
@@ -453,195 +453,196 @@ class RC:
     def EIgross(self, axis):
         return self.Ec * self.Ic(axis) + self.Es * self.Isr(axis)
     
+    # Built-in effective stiffness methods.
+    _BUILTIN_EI_TYPES = ('aci-a', 'aci-b', 'aci-c', 'jf-a', 'jf-b', 'gross',
+                         'proposed_1_1', 'proposed_1_2', 'proposed_2')
+
+    @staticmethod
+    def _as_load_arrays(EI_type, P, M, require_M=True):
+        """Normalize P and M to float arrays; say whether the input was scalar."""
+        if P is None:
+            raise ValueError(f"P must be defined for EI_type = {EI_type!r}")
+        if require_M and M is None:
+            raise ValueError(f"M must be defined for EI_type = {EI_type!r}")
+
+        try:
+            P_array = np.asarray(P, dtype=float)
+            M_array = np.asarray(0.0 if M is None else M, dtype=float)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f'P and M must be numeric for EI_type = {EI_type!r} '
+                f'(got P={P!r}, M={M!r})') from exc
+
+        try:
+            shape = np.broadcast_shapes(P_array.shape, M_array.shape)
+        except ValueError as exc:
+            raise ValueError(
+                f'P and M must have compatible shapes for EI_type = {EI_type!r} '
+                f'(got {P_array.shape} and {M_array.shape})') from exc
+
+        scalar_input = shape == ()
+        P_array = np.broadcast_to(P_array, shape)
+        M_array = np.broadcast_to(M_array, shape)
+        return np.atleast_1d(P_array), np.atleast_1d(M_array), scalar_input
+
+    @staticmethod
+    def _eccentricity_ratio(P, M, depth):
+        """abs(M) / abs(P) / depth.
+
+        P == 0 gives infinity, which pushes the method to its lower bound.
+        P == 0 with M == 0 gives NaN.
+        """
+        with np.errstate(divide='ignore', invalid='ignore'):
+            return np.abs(M) / np.abs(P) / depth
+
+    @staticmethod
+    def _match_load_shape(value, scalar_input):
+        """Return a scalar for scalar input, otherwise the array unchanged."""
+        return float(value[0]) if scalar_input else np.asarray(value)
+
     def EIeff(self, axis, EI_type, betadns=0.0, P=None, M=None, col=None):
-        if EI_type.lower() == "aci-a":
+        """Effective flexural stiffness.
+
+        Parameters
+        ----------
+        axis : str
+            'x' or 'y'.
+        EI_type : str
+            One of: aci-a, aci-b, aci-c, jf-a, jf-b, gross, proposed_1_1,
+            proposed_1_2, proposed_2. Case and spaces are ignored. A
+            '<module>,<arg>' string resolves a function from that module.
+        betadns : float
+            Sustained load ratio. Must be greater than -1.
+        P, M : scalar or array-like, optional
+            Axial load and moment, required by the load-dependent methods.
+            Scalar in, scalar out; array in, array out.
+        col : object, optional
+            Column, required by proposed_2.
+
+        Notes
+        -----
+        P == 0 with M != 0 returns the method lower bound. P == 0 with
+        M == 0 returns NaN.
+        """
+        # --- shared validation --------------------------------------------
+        if 1 + betadns <= 0:
+            raise ValueError(
+                f'betadns must be greater than -1 because 1 + betadns divides the '
+                f'effective stiffness (got {betadns!r})')
+
+        key = EI_type.strip().lower()
+        Ig = self.Ig(axis)
+        Ec = self.Ec
+        creep_factor = 1 + betadns
+
+        # --- load independent methods -------------------------------------
+        if key == 'aci-a':
             # ACI 318-19, Section 6.6.4.4.4a
-            return 0.4 * self.Ec * self.Ig(axis) / (1 + betadns)
+            return 0.4 * Ec * Ig / creep_factor
 
-        elif EI_type.lower() == "aci-b":
+        if key == 'aci-b':
             # ACI 318-19, Section 6.6.4.4.4b
-            return (0.2 * self.Ec * self.Ig(axis) + self.Es * self.Isr(axis)) / (1 + betadns)
+            return (0.2 * Ec * Ig + self.Es * self.Isr(axis)) / creep_factor
 
-        elif EI_type.lower() == "aci-c":
-            # ACI 318-19, Section 6.6.4.4.4c
-            if P is None or M is None:
-                raise ValueError("P and M must be defined for EI_type = 'ACI-c'")
-            Ieff = []
-            max_I = 0.875 * self.Ig(axis)
-            min_I = 0.35 * self.Ig(axis)
-            if isinstance(P, (list, np.ndarray)):
-                for P, M in zip(P, M):
-                    I_ACI = (0.8 + 25 * self.Asr / self.Ag) * (
-                            1 - M / P / self.depth(axis) - 0.5 * P / self.p0) * self.Ig(axis)
-                    if I_ACI > max_I:
-                        Ieff.append(max_I)
-                    elif I_ACI < min_I:
-                        Ieff.append(min_I)
-                    else:
-                        Ieff.append(I_ACI)
-                EI = [i * self.Ec for i in Ieff]
-                return EI
-
-            elif isinstance(P, float):
-                I_ACI = (0.8 + 25 * self.Asr / self.Ag) * (
-                            1 - M / P / self.depth(axis) - 0.5 * P / self.p0) * self.Ig(axis)
-                if I_ACI > max_I:
-                    Ieff = max_I
-                elif I_ACI < min_I:
-                    Ieff = min_I
-                else:
-                    Ieff = I_ACI
-                EI = Ieff * self.Ec
-                return EI
-
-        elif EI_type.lower() == "jf-a":
-            # Jenkins and Frosch, 2011 - Eq.10.1
-            EI = []
-            if P is None or M is None:
-                raise ValueError("P and M must be defined for EI_type = 'JF-a'")
-            elif isinstance(P, (list, np.ndarray)) and isinstance(M, (list, np.ndarray)):
-                if len(P) != len(M):
-                    raise ValueError("P and M must be of the same size")
-                for P, M in zip(P, M):
-                    ecc_ratio = abs(M) / abs(P) / self.depth(axis)
-                    if ecc_ratio <= 0.1:
-                        EI_jenkins = (1.05 - 0.6 * abs(P) / self.p0) * (1 + 3 * (self.Asr / self.Ag - 0.01)) *\
-                                     self.Ec * self.Ig(axis) / (1 + betadns)
-                        min_EI = 0.3 * self.Ec * self.Ig(axis) / (1 + betadns)
-                        EI.append(max(EI_jenkins, min_EI))
-                    else:
-                        EI_jenkins = (1.05 - 0.6 * abs(P) / self.p0) * (1 + 3 * (self.Asr / self.Ag - 0.01)) * (
-                                1.2 - 2 * ecc_ratio) * self.Ec * self.Ig(axis) / (1 + betadns)
-                        min_EI = 0.3 * self.Ec * self.Ig(axis) / (1 + betadns)
-                        EI.append(max(EI_jenkins, min_EI))
-                return EI
-
-            elif isinstance(P, (float, np.float64, int)) and isinstance(M, (float, np.float64, int)):
-                try:
-                    ecc_ratio = abs(M) / abs(P) / self.depth(axis)
-                except ZeroDivisionError:
-                    return np.nan
-                if ecc_ratio <= 0.1:
-                    EI_jenkins = (1.05 - 0.6 * abs(P) / self.p0) * (1 + 3 * (self.Asr / self.Ag - 0.01)) * \
-                                 self.Ec * self.Ig(axis) / (1 + betadns)
-                    min_EI = 0.3 * self.Ec * self.Ig(axis) / (1 + betadns)
-                    EI = max(EI_jenkins, min_EI)
-                else:
-                    EI_jenkins = (1.05 - 0.6 * abs(P) / self.p0) * (1 + 3 * (self.Asr / self.Ag - 0.01)) * (
-                            1.2 - 2 * ecc_ratio) * self.Ec * self.Ig(axis) / (1 + betadns)
-                    min_EI = 0.3 * self.Ec * self.Ig(axis) / (1 + betadns)
-                    EI = max(EI_jenkins, min_EI)
-                return EI
-
-            else:
-                raise ValueError("P and M types or sizes are not as expected")
-
-        elif EI_type.lower() == "jf-b":
-            # Jenkins and Frosch, 2011 - Eq.10.2
-            EI = []
-            if P is None or M is None:
-                raise ValueError("P and M must be defined for EI_type = 'JF-b'")
-
-            elif isinstance(P, (list, np.ndarray)) and isinstance(M, (list, np.ndarray)):
-                if len(P) != len(M):
-                    raise ValueError("P and M must be of the same size")
-                for P, M in zip(P, M):
-                    ecc_ratio = M / P / self.depth(axis)
-                    if ecc_ratio <= 0.1:
-                        EI_jenkins = (1.0 - 0.5 * P / self.p0) * self.Ec * self.Ig(axis) / (1 + betadns)
-                        min_EI = 0.4 * self.Ec * self.Ig(axis) / (1 + betadns)
-                        EI.append(max(EI_jenkins, min_EI))
-                    else:
-                        EI_jenkins = (1.0 - 0.5 * P / self.p0) * self.Ec * self.Ig(axis) * (
-                            1.2 - 2 * ecc_ratio) / (1 + betadns)
-                        min_EI = 0.4 * self.Ec * self.Ig(axis) / (1 + betadns)
-                        EI.append(max(EI_jenkins, min_EI))
-                return EI
-
-            elif isinstance(P, (float, np.float64, int)) and isinstance(M, (float, np.float64, int)):
-                try:
-                    ecc_ratio = abs(M) / abs(P) / self.depth(axis)
-                except ZeroDivisionError:
-                    return np.nan
-                if ecc_ratio <= 0.1:
-                    EI_jenkins = (1.0 - 0.5 * P / self.p0) * self.Ec * self.Ig(axis) / (1 + betadns)
-                    min_EI = 0.4 * self.Ec * self.Ig(axis) / (1 + betadns)
-                    EI = max(EI_jenkins, min_EI)
-                else:
-                    EI_jenkins = (1.0 - 0.5 * P / self.p0) * self.Ec * self.Ig(axis) * (
-                            1.2 - 2 * ecc_ratio) / (1 + betadns)
-                    min_EI = 0.4 * self.Ec * self.Ig(axis) / (1 + betadns)
-                    EI = max(EI_jenkins, min_EI)
-                return EI
-
-            else:
-                raise ValueError("P and M types or sizes are not as expected")
-
-        elif EI_type.lower() == "gross":
+        if key == 'gross':
             return self.EIgross(axis)
 
-        if EI_type == "proposed_1_1":
-            Mn = self.Mn(axis)
-            if M / Mn <= 0.95:
-                return 0.4 * self.Ec * self.Ig(axis) / (1 + betadns)
-            else:
-                return 1 * self.Es * self.Isr(axis) / (1 + betadns)
+        # --- load dependent methods ---------------------------------------
+        if key == 'aci-c':
+            # ACI 318-19, Section 6.6.4.4.4c
+            P_arr, M_arr, scalar_input = self._as_load_arrays(EI_type, P, M)
+            max_I = 0.875 * Ig
+            min_I = 0.35 * Ig
+            # As P -> 0 the clip returns min_I, the pure-bending limit.
+            with np.errstate(divide='ignore', invalid='ignore'):
+                I_ACI = (0.8 + 25 * self.Asr / self.Ag) * (
+                        1 - M_arr / P_arr / self.depth(axis)
+                        - 0.5 * P_arr / self.p0) * Ig
+            Ieff = np.clip(I_ACI, min_I, max_I)
+            return self._match_load_shape(Ieff * Ec, scalar_input)
 
-        if EI_type == "proposed_1_2":
-            Mn = self.Mn(axis)
-            if M / Mn <= 0.95:
-                return (0.2 * self.Ec * self.Ig(axis) + self.Es * self.Isr(axis)) / (1 + betadns)
-            else:
-                return 1 * self.Es * self.Isr(axis) / (1 + betadns)
+        if key == 'jf-a':
+            # Jenkins and Frosch, 2011 - Eq.10.1
+            P_arr, M_arr, scalar_input = self._as_load_arrays(EI_type, P, M)
+            ecc_ratio = self._eccentricity_ratio(P_arr, M_arr, self.depth(axis))
+            shape_factor = np.where(ecc_ratio <= 0.1, 1.0, 1.2 - 2 * ecc_ratio)
+            EI_jenkins = ((1.05 - 0.6 * np.abs(P_arr) / self.p0)
+                          * (1 + 3 * (self.Asr / self.Ag - 0.01))
+                          * shape_factor * Ec * Ig / creep_factor)
+            min_EI = 0.3 * Ec * Ig / creep_factor
+            return self._match_load_shape(np.maximum(EI_jenkins, min_EI), scalar_input)
 
-        elif EI_type == "proposed_2":
-            EI_gross = self.Ec * self.Ig(axis)
-            P_P0 = P / self.p0
+        if key == 'jf-b':
+            # Jenkins and Frosch, 2011 - Eq.10.2
+            # Eccentricity ratio uses magnitudes, as in JF-a.
+            P_arr, M_arr, scalar_input = self._as_load_arrays(EI_type, P, M)
+            ecc_ratio = self._eccentricity_ratio(P_arr, M_arr, self.depth(axis))
+            shape_factor = np.where(ecc_ratio <= 0.1, 1.0, 1.2 - 2 * ecc_ratio)
+            EI_jenkins = ((1.0 - 0.5 * P_arr / self.p0)
+                          * Ec * Ig * shape_factor / creep_factor)
+            min_EI = 0.4 * Ec * Ig / creep_factor
+            return self._match_load_shape(np.maximum(EI_jenkins, min_EI), scalar_input)
+
+        if key in ('proposed_1_1', 'proposed_1_2'):
+            _, M_arr, scalar_input = self._as_load_arrays(EI_type, 0.0, M)
+            Mn = self.Mn(axis)
+            if key == 'proposed_1_1':
+                low = 0.4 * Ec * Ig / creep_factor
+            else:
+                low = (0.2 * Ec * Ig + self.Es * self.Isr(axis)) / creep_factor
+            high = 1 * self.Es * self.Isr(axis) / creep_factor
+            EI_values = np.where(M_arr / Mn <= 0.95, low, high)
+            return self._match_load_shape(EI_values, scalar_input)
+
+        if key == 'proposed_2':
+            if col is None:
+                raise ValueError("col must be defined for EI_type = 'proposed_2'")
+            P_arr, _, scalar_input = self._as_load_arrays(EI_type, P, M, require_M=False)
+            EI_gross = Ec * Ig
             P0 = self.p0
-            As_Ag = self.Asr / self.Ag
-            r = np.sqrt(self.Ig(axis) / self.Ag)
+            r = np.sqrt(Ig / self.Ag)
             L = col.length
 
             if type(col).__name__ == 'NonSwayColumn2d':
                 K = 1
-                EI = (0.45 * P / P0 + 0.35 * ((K * L / r) / 100) ** 1.85 * np.sin(
-                    np.pi * P / P0)) * EI_gross + 0.3* self.Es * self.Isr(axis) / (1 + betadns)
-                return EI
-
             elif type(col).__name__ == 'SwayColumn2d':
                 K = col.effective_length_factor(0.4 * EI_gross)
-                EI = (0.45 * P / P0 + 0.35 * ((K * L / r) / 100) ** 1.85 * np.sin(
-                    np.pi * P / P0)) * EI_gross + 0.3* self.Es * self.Isr(axis) / (1 + betadns)
-                return EI
-
-        
-        else:
-            # Fall back to resolving EI_type as '<module>,<argument>'. Only the
-            # resolution is guarded: a bare except also swallowed errors raised
-            # inside the resolved function and reported them as an unknown
-            # EI_type, hiding the real failure.
-            import importlib
-
-            try:
-                module_name, EI_input = EI_type.split(',')
-            except (AttributeError, ValueError) as exc:
+            else:
                 raise ValueError(
-                    f'Unknown EI_type {EI_type!r}. Expected one of the built-in method '
-                    f"names, or '<module>,<argument>' naming a module that defines a "
-                    f'function of the same name.') from exc
+                    f"EI_type 'proposed_2' does not support column type "
+                    f'{type(col).__name__}')
 
-            try:
-                module = importlib.import_module(module_name)
-                EI_trial = getattr(module, module_name)
-            except (ImportError, AttributeError) as exc:
-                raise ValueError(
-                    f'Unknown EI_type {EI_type!r}: could not resolve a function named '
-                    f'{module_name!r} in a module of that name.') from exc
+            EI_values = ((0.45 * P_arr / P0
+                          + 0.35 * ((K * L / r) / 100) ** 1.85
+                          * np.sin(np.pi * P_arr / P0)) * EI_gross
+                         + 0.3 * self.Es * self.Isr(axis) / creep_factor)
+            return self._match_load_shape(EI_values, scalar_input)
 
-            # The module must define a function with the same name as the
-            # module itself, callable as func(section, axis, arg, betadns,
-            # P, M, col).
-            return EI_trial(self, axis, EI_input, betadns, P, M, col)
+        # --- '<module>,<argument>' fallback --------------------------------
+        # Only the resolution is guarded, so errors raised inside the
+        # resolved function are not reported as an unknown EI_type.
+        import importlib
+
+        try:
+            module_name, EI_input = EI_type.split(',')
+        except ValueError as exc:
+            raise ValueError(
+                f'Unknown EI_type {EI_type!r}. Expected one of '
+                f"{', '.join(self._BUILTIN_EI_TYPES)}, or "
+                f"'<module>,<argument>' naming a module that defines a function "
+                f'of the same name.') from exc
+
+        try:
+            module = importlib.import_module(module_name)
+            EI_trial = getattr(module, module_name)
+        except (ImportError, AttributeError) as exc:
+            raise ValueError(
+                f'Unknown EI_type {EI_type!r}: could not resolve a function named '
+                f'{module_name!r} in a module of that name.') from exc
+
+        # The module must define a function of the same name, called as
+        # func(section, axis, arg, betadns, P, M, col).
+        return EI_trial(self, axis, EI_input, betadns, P, M, col)
 
     def interaction_diagram_object(self, axis, num_points=20, factored=False, only_compressive=True):
         # Cache on every input that changes the diagram. A single cached object

--- a/src/libdenavit/section/RC.py
+++ b/src/libdenavit/section/RC.py
@@ -1108,17 +1108,24 @@ class RC:
                     ops.patch('rect', concrete_material_id, nfy, nfx, -H / 2, -B / 2, H / 2, B / 2)
 
             elif axis in ['x', 'y']:
+                # H is the section depth in the direction of bending, B the
+                # width perpendicular to it, and nfd the fiber count through
+                # the depth (nfx is ignored for x bending, nfy for y bending).
+                # reinf_depth is the reinforcement extent measured through the
+                # same depth direction: By for x bending, Bx for y bending.
+                if axis == 'x':
+                    H = self.conc_cross_section.H
+                    B = self.conc_cross_section.B
+                    nfd = nfy
+                    reinf_depth = self.reinforcement[0].By
+                else:
+                    H = self.conc_cross_section.B
+                    B = self.conc_cross_section.H
+                    nfd = nfx
+                    reinf_depth = self.reinforcement[0].Bx
+
                 for i in self.reinforcement:
-                    if axis == 'x':
-                        rebar_coords = i.coordinates[1]
-                        H = self.conc_cross_section.H
-                        B = self.conc_cross_section.B
-                        nfd = nfy
-                    else:
-                        rebar_coords = i.coordinates[0]
-                        H = self.conc_cross_section.B
-                        B = self.conc_cross_section.H
-                        nfd = nfx
+                    rebar_coords = i.coordinates[1] if axis == 'x' else i.coordinates[0]
 
                     for index, value in enumerate(rebar_coords):
                         ops.fiber(float(value), 0, i.Ab, steel_material_id)
@@ -1128,7 +1135,7 @@ class RC:
                             negative_area_material_id = concrete_material_id
                         ops.fiber(float(value), 0, -i.Ab, negative_area_material_id)
 
-                cdb = (H - self.reinforcement[0].By) / 2 - self.reinforcement[0].db / 2
+                cdb = (H - reinf_depth) / 2 - self.reinforcement[0].db / 2
                 if self.dbt is not None:
                     cdb = cdb - self.dbt / 2
                 if confinement:
@@ -1147,6 +1154,9 @@ class RC:
                 else:
                     fiber_height = H / nfd
                     ops.layer('straight', concrete_material_id, nfd, fiber_height * B, -H / 2, 0, H / 2, 0)
+
+            else:
+                raise ValueError(f'Unknown option for axis: {axis}')
 
         elif type(self.conc_cross_section).__name__ == 'Circle':
             if (axis is None) or (axis == '3d'):
@@ -1194,7 +1204,7 @@ class RC:
                     else:
                         rebar_coords = i.coordinates[0]
 
-                    for index, value in enumerate(i.coordinates[1]):
+                    for index, value in enumerate(rebar_coords):
                         ops.fiber(value, 0, i.Ab, steel_material_id)
                         if confinement:
                             negative_area_material_id = core_concrete_material_id
@@ -1203,7 +1213,8 @@ class RC:
                         ops.fiber(value, 0, -i.Ab, negative_area_material_id)
 
                 d = self.conc_cross_section.diameter
-                max_fiber_size = d / nfy
+                # nfx is ignored for x bending, nfy for y bending
+                max_fiber_size = d / (nfy if axis == 'x' else nfx)
                 if confinement:
                     ds = 2*self.reinforcement[0].rc + self.reinforcement[0].db + self.dbt
                     nf = ceil(0.5*ds/max_fiber_size)
@@ -1221,8 +1232,6 @@ class RC:
                 raise ValueError(f'3D option not supported for obround cross-sections yet')
 
             elif axis == 'x' or axis == 'y':
-                ds = self.reinforcement[0].D + self.reinforcement[0].db + self.dbt
-
                 if confinement:
                     negative_area_material_id = core_concrete_material_id
                 else:
@@ -1238,12 +1247,11 @@ class RC:
                             ops.fiber(value, 0, i.Ab, steel_material_id)
                             ops.fiber(value, 0, -i.Ab, negative_area_material_id)
 
-                if axis == 'x':
-                    nf = nfx
-                elif axis == 'y':
-                    nf = nfy
+                # nfx is ignored for x bending, nfy for y bending
+                nf = nfy if axis == 'x' else nfx
 
                 if confinement:
+                    ds = self.reinforcement[0].D + self.reinforcement[0].db + self.dbt
                     obround_patch_2d_confined(cover_concrete_material_id, core_concrete_material_id, nf,
                                               self.conc_cross_section.D, self.conc_cross_section.a, ds,
                                               axis=axis)

--- a/src/libdenavit/section/RC.py
+++ b/src/libdenavit/section/RC.py
@@ -653,7 +653,7 @@ class RC:
             return (0.2 * Ec * Ig + self.Es * self.Isr(axis)) / creep_factor
 
         if key == 'gross':
-            return self.EIgross(axis)
+            return self.EIgross(axis) / creep_factor
 
         # --- load dependent methods ---------------------------------------
         if key == 'aci-c':
@@ -667,7 +667,7 @@ class RC:
                         1 - M_arr / P_arr / self.depth(axis)
                         - 0.5 * P_arr / self.p0) * Ig
             Ieff = np.clip(I_ACI, min_I, max_I)
-            return self._match_load_shape(Ieff * Ec, scalar_input)
+            return self._match_load_shape(Ieff * Ec / creep_factor, scalar_input)
 
         if key == 'jf-a':
             # Jenkins and Frosch, 2011 - Eq.10.1
@@ -723,7 +723,7 @@ class RC:
             EI_values = ((0.45 * P_arr / P0
                           + 0.35 * ((K * L / r) / 100) ** 1.85
                           * np.sin(np.pi * P_arr / P0)) * EI_gross
-                         + 0.3 * self.Es * self.Isr(axis) / creep_factor)
+                         + 0.3 * self.Es * self.Isr(axis)) / creep_factor
             return self._match_load_shape(EI_values, scalar_input)
 
         # --- '<module>,<argument>' fallback --------------------------------

--- a/src/libdenavit/section/RC.py
+++ b/src/libdenavit/section/RC.py
@@ -328,7 +328,7 @@ class RC:
         if self.units == 'si':
             return (self.fc * 145.038) ** (1 / 4) / 4000
 
-        raise ValueError(f'eps_c is not set and default is not impleted for {self.units = }')
+        raise ValueError(f'eps_c is not set and default is not implemented for {self.units = }')
     @eps_c.setter
     def eps_c(self, x):
         self._invalidate_section_caches()
@@ -616,15 +616,32 @@ class RC:
 
         
         else:
+            # Fall back to resolving EI_type as '<module>,<argument>'. Only the
+            # resolution is guarded: a bare except also swallowed errors raised
+            # inside the resolved function and reported them as an unknown
+            # EI_type, hiding the real failure.
+            import importlib
+
             try:
-                import importlib
                 module_name, EI_input = EI_type.split(',')
-                func_name = module_name
+            except (AttributeError, ValueError) as exc:
+                raise ValueError(
+                    f'Unknown EI_type {EI_type!r}. Expected one of the built-in method '
+                    f"names, or '<module>,<argument>' naming a module that defines a "
+                    f'function of the same name.') from exc
+
+            try:
                 module = importlib.import_module(module_name)
-                EI_trial = getattr(module, func_name)
-                return EI_trial(self, axis, EI_input, betadns, P, M, col)
-            except:
-                raise ValueError(f'Unknown EI_type {EI_type}')
+                EI_trial = getattr(module, module_name)
+            except (ImportError, AttributeError) as exc:
+                raise ValueError(
+                    f'Unknown EI_type {EI_type!r}: could not resolve a function named '
+                    f'{module_name!r} in a module of that name.') from exc
+
+            # The module must define a function with the same name as the
+            # module itself, callable as func(section, axis, arg, betadns,
+            # P, M, col).
+            return EI_trial(self, axis, EI_input, betadns, P, M, col)
 
     def interaction_diagram_object(self, axis, num_points=20, factored=False, only_compressive=True):
         # Cache on every input that changes the diagram. A single cached object

--- a/src/libdenavit/section/RC.py
+++ b/src/libdenavit/section/RC.py
@@ -368,24 +368,25 @@ class RC:
             return extreme_strain
 
         if type(self.conc_cross_section).__name__ == 'Obround':
-            extreme_strain = float("inf")
-            for i in range(100):
-                x_coord = self.conc_cross_section.a/2 + self.conc_cross_section.D/2 * sin(pi/2 * i/100)
-                y_coord = self.conc_cross_section.D/2 - self.conc_cross_section.D/2 * sin(pi/2 * i/100)
-                strain = axial_strain - y_coord * abs(curvatureX) - x_coord * abs(curvatureY)
-                if strain < extreme_strain:
-                    extreme_strain = strain
+            a = self.conc_cross_section.a
+            D = self.conc_cross_section.D
+            extreme_strain = axial_strain \
+                - (a / 2) * abs(curvatureY) \
+                - (D / 2) * sqrt(curvatureX ** 2 + curvatureY ** 2)
             return extreme_strain
 
         raise ValueError(f'No maximum concrete compression strain implemented for {type(self.conc_cross_section).__name__ = }')
 
     def maximum_tensile_steel_strain(self, axial_strain, curvatureX=0, curvatureY=0):
         max_strain = float('-inf')
-        for i in self.reinforcement[0].coordinates:
-            strain = axial_strain - (i[1] - self.reinforcement[0].yc) * curvatureX \
-                     - (i[0] - self.reinforcement[0].xc) * curvatureY
-            if strain > max_strain:
-                max_strain = strain
+        for pattern in self.reinforcement:
+            x_coordinates, y_coordinates = pattern.coordinates
+            for x, y in zip(x_coordinates, y_coordinates):
+                strain = axial_strain - y * curvatureX - x * curvatureY
+                if strain > max_strain:
+                    max_strain = strain
+        if max_strain == float('-inf'):
+            raise ValueError('No reinforcing bars found to compute a maximum tensile steel strain')
         return max_strain
 
     def maximum_tensile_strain(self, axial_strain, curvatureX=0, curvatureY=0):

--- a/src/libdenavit/section/RC.py
+++ b/src/libdenavit/section/RC.py
@@ -56,8 +56,6 @@ class RC:
         self._Ec = x
 
     def get_shrinkage_props_for_uniaxial_material(self, print_factors=False, **kwargs):
-        if kwargs is None:
-            kwargs = {}
         # Define default values for 'si' and 'us' units
         default_values = {'si':
                               {'eps_sh_u0': 780e-6,  # ultimate shrinkage strain
@@ -96,7 +94,7 @@ class RC:
 
         try:
             VoverS = kwargs['VoverS']
-        except:
+        except KeyError:
             VoverS = self.conc_cross_section.A / self.conc_cross_section.perimeter
 
         slump = kwargs['slump']
@@ -177,8 +175,6 @@ class RC:
         return {'eps_sh_u': eps_sh_u, 'f': f, 'psish': f}
 
     def get_creep_props_for_uniaxial_material(self, print_factors=False, **kwargs):
-        if kwargs is None:
-            kwargs = {}
         # Define default values for 'si' and 'us' units
         default_values = {'si':
                               {'phi_u_0': 2.35,  # ultimate creep coefficient
@@ -212,7 +208,7 @@ class RC:
         RH = kwargs['RH']
         try:
             VoverS = kwargs['VoverS']
-        except:
+        except KeyError:
             VoverS = self.conc_cross_section.A / self.conc_cross_section.perimeter
         slump = kwargs['slump']
         fine_agg_ratio = kwargs['fine_agg_ratio']
@@ -1004,8 +1000,8 @@ class RC:
 
         # region Define Creep Material
         if creep:
-            creepdata = self.get_creep_props_for_uniaxial_material(**creep_props_dict)
-            shrinkagedata = self.get_shrinkage_props_for_uniaxial_material(**shrinkage_props_dict)
+            creepdata = self.get_creep_props_for_uniaxial_material(**(creep_props_dict or {}))
+            shrinkagedata = self.get_shrinkage_props_for_uniaxial_material(**(shrinkage_props_dict or {}))
 
             if self._default_age_warn:
                 if self.tD == 5:

--- a/src/libdenavit/section/RC.py
+++ b/src/libdenavit/section/RC.py
@@ -321,10 +321,23 @@ class RC:
         return self._reinforcement
     @reinforcement.setter
     def reinforcement(self, x):
-        if type(x) == list:
-            self._reinforcement = x
+        """
+        Store the reinforcement as a list of patterns.
+
+        A single pattern object becomes a one-item list; a list or tuple is
+        copied into a new list.
+        """
+        if isinstance(x, (list, tuple)):
+            patterns = list(x)
         else:
-            self._reinforcement = [x]
+            patterns = [x]
+
+        if not patterns:
+            # Several methods (validate_section_reinf, maximum_tensile_steel_strain)
+            # index reinforcement[0], so concrete-only sections are not supported.
+            raise ValueError('reinforcement must contain at least one reinforcement pattern')
+
+        self._reinforcement = patterns
 
     def depth(self, axis):
         return self.conc_cross_section.depth(axis)
@@ -885,19 +898,24 @@ class RC:
         # endregion
 
         # region Define Concrete Material
+        # Reinforcement pattern required by each concrete cross-section type.
+        supported_reinf_for_section = {
+            'Rectangle': 'ReinfRect',
+            'Circle': 'ReinfCirc',
+            'Obround': 'ReinfIntersectingLoops',
+        }
+
         def validate_section_reinf(self):
-            if type(self.conc_cross_section).__name__ == 'Rectangle':
-                if type(self.reinforcement[0]).__name__ != 'ReinfRect':
+            section_name = type(self.conc_cross_section).__name__
+            expected = supported_reinf_for_section.get(section_name)
+            if expected is not None:
+                actual = type(self.reinforcement[0]).__name__
+                if actual != expected:
+                    # Report the offending pattern type, not the container type:
+                    # type(self.reinforcement).__name__ is always 'list'.
                     raise ValueError(
-                        f"Reinforcement type {type(self.reinforcement).__name__} not supported for this section type")
-            if type(self.conc_cross_section).__name__ == 'Circle':
-                if type(self.reinforcement[0]).__name__ != 'ReinfCirc':
-                    raise ValueError(
-                        f"Reinforcement type {type(self.reinforcement).__name__} not supported for this section type")
-            if type(self.conc_cross_section).__name__ == 'Obround':
-                if type(self.reinforcement[0]).__name__ != 'ReinfIntersectingLoops':
-                    raise ValueError(
-                        f"Reinforcement type {type(self.reinforcement).__name__} not supported for this section type")
+                        f"Reinforcement type {actual} not supported for section type "
+                        f"{section_name} (expected {expected})")
 
             if self.reinforcement[0].xc != 0 or self.reinforcement[0].yc != 0:
                 raise ValueError(f"Reinforcing pattern must be centered")

--- a/src/libdenavit/section/RC.py
+++ b/src/libdenavit/section/RC.py
@@ -457,6 +457,9 @@ class RC:
     _BUILTIN_EI_TYPES = ('aci-a', 'aci-b', 'aci-c', 'jf-a', 'jf-b', 'gross',
                          'proposed_1_1', 'proposed_1_2', 'proposed_2')
 
+    # Keyword arguments a custom EI callable always receives.
+    _EI_RESERVED_KWARGS = ('section', 'axis', 'betadns', 'P', 'M', 'col')
+
     @staticmethod
     def _as_load_arrays(EI_type, P, M, require_M=True):
         """Normalize P and M to float arrays; say whether the input was scalar."""
@@ -500,7 +503,57 @@ class RC:
         """Return a scalar for scalar input, otherwise the array unchanged."""
         return float(value[0]) if scalar_input else np.asarray(value)
 
-    def EIeff(self, axis, EI_type, betadns=0.0, P=None, M=None, col=None):
+    def _custom_EIeff(self, custom, axis, betadns, P, M, col, EI_kwargs):
+        """Evaluate a user supplied constant or callable effective stiffness."""
+        EI_kwargs = dict(EI_kwargs or {})
+
+        if callable(custom):
+            clashes = sorted(set(EI_kwargs) & set(self._EI_RESERVED_KWARGS))
+            if clashes:
+                raise ValueError(
+                    f'EI_kwargs may not override the reserved arguments '
+                    f'{clashes}; they are always supplied by EIeff.')
+            value = custom(section=self, axis=axis, betadns=betadns,
+                           P=P, M=M, col=col, **EI_kwargs)
+        else:
+            if EI_kwargs:
+                raise ValueError(
+                    'EI_kwargs is only meaningful when the custom EI is callable; '
+                    f'got a {type(custom).__name__}.')
+            value = custom
+
+        try:
+            value = np.asarray(value, dtype=float)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f'Custom EI must be numeric, got {value!r}') from exc
+
+        if value.size == 0:
+            raise ValueError('Custom EI must not be empty')
+        if not np.all(np.isfinite(value)):
+            raise ValueError(f'Custom EI must be finite, got {value!r}')
+        if np.any(value <= 0):
+            raise ValueError(f'Custom EI must be positive, got {value!r}')
+
+        # Match the shape implied by the loads, if any were supplied.
+        load_shape = ()
+        for load in (P, M):
+            if load is not None:
+                load_shape = np.broadcast_shapes(
+                    load_shape, np.asarray(load, dtype=float).shape)
+
+        if value.ndim == 0:
+            if load_shape == ():
+                return float(value)
+            return np.broadcast_to(value, load_shape).copy()
+
+        if load_shape not in ((), value.shape):
+            raise ValueError(
+                f'Custom EI shape {value.shape} does not match the load shape '
+                f'{load_shape}')
+        return value
+
+    def EIeff(self, axis, EI_type=None, betadns=0.0, P=None, M=None, col=None,
+              EI=None, EI_kwargs=None):
         """Effective flexural stiffness.
 
         Parameters
@@ -510,7 +563,8 @@ class RC:
         EI_type : str
             One of: aci-a, aci-b, aci-c, jf-a, jf-b, gross, proposed_1_1,
             proposed_1_2, proposed_2. Case and spaces are ignored. A
-            '<module>,<arg>' string resolves a function from that module.
+            '<module>,<arg>' string resolves a function from that module. A
+            non-string value is treated as a custom EI.
         betadns : float
             Sustained load ratio. Must be greater than -1.
         P, M : scalar or array-like, optional
@@ -518,12 +572,40 @@ class RC:
             Scalar in, scalar out; array in, array out.
         col : object, optional
             Column, required by proposed_2.
+        EI : float or callable, optional
+            Custom effective stiffness. A constant is used directly. A callable
+            is invoked with the reserved keyword arguments section, axis,
+            betadns, P, M and col, plus anything in EI_kwargs, and must return
+            a finite positive stiffness.
+        EI_kwargs : dict, optional
+            Extra keyword arguments for a callable EI. Rejected for a constant
+            EI, and may not shadow the reserved names.
 
         Notes
         -----
         P == 0 with M != 0 returns the method lower bound. P == 0 with
         M == 0 returns NaN.
         """
+        # --- custom effective stiffness -----------------------------------
+        custom = None
+        if EI is not None and EI_type is not None and not isinstance(EI_type, str):
+            raise ValueError(
+                'Provide a custom EI through either EI or a non-string EI_type, '
+                'not both.')
+        if EI is not None:
+            custom = EI
+        elif EI_type is not None and not isinstance(EI_type, str):
+            custom = EI_type
+
+        if custom is not None:
+            return self._custom_EIeff(custom, axis, betadns, P, M, col, EI_kwargs)
+
+        if EI_type is None:
+            raise ValueError('EI_type or EI must be provided')
+
+        if EI_kwargs:
+            raise ValueError('EI_kwargs is only meaningful together with a custom EI')
+
         # --- shared validation --------------------------------------------
         if 1 + betadns <= 0:
             raise ValueError(
@@ -628,7 +710,7 @@ class RC:
         except ValueError as exc:
             raise ValueError(
                 f'Unknown EI_type {EI_type!r}. Expected one of '
-                f"{', '.join(self._BUILTIN_EI_TYPES)}, or "
+                f"{', '.join(self._BUILTIN_EI_TYPES)}, a custom EI, or "
                 f"'<module>,<argument>' naming a module that defines a function "
                 f'of the same name.') from exc
 

--- a/src/libdenavit/section/RC.py
+++ b/src/libdenavit/section/RC.py
@@ -38,11 +38,29 @@ class RC:
 
 
 
+    @staticmethod
+    def _require_positive(name, value):
+        """Reject a non-finite or non-positive material property.
+
+        A negative modulus propagates silently into a negative EIgross, and
+        a negative fc reaches sqrt() as a bare math domain error.
+        """
+        if value is None:
+            raise ValueError(f'{name} must be set to a finite positive value')
+        try:
+            numeric = float(value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f'{name} must be numeric (got {value!r})') from exc
+        if not np.isfinite(numeric) or numeric <= 0:
+            raise ValueError(f'{name} must be a finite positive value (got {value!r})')
+        return numeric
+
     @property
     def Ec(self):
         if self._Ec is not None:
             return self._Ec
 
+        self._require_positive('fc', self.fc)
         if self.units == 'us':
             return 57 * sqrt(self.fc * 1000)
 
@@ -52,6 +70,8 @@ class RC:
         raise ValueError(f'Ec is not set and default is not implemented for {self.units = }')
     @Ec.setter
     def Ec(self, x):
+        if x is not None:
+            self._require_positive('Ec', x)
         self._invalidate_section_caches()
         self._Ec = x
 
@@ -316,6 +336,8 @@ class RC:
         raise ValueError(f'Es is not set and default is not implemented for {self.units = }')
     @Es.setter
     def Es(self, x):
+        if x is not None:
+            self._require_positive('Es', x)
         self._invalidate_section_caches()
         self._Es = x
 
@@ -331,6 +353,8 @@ class RC:
         raise ValueError(f'eps_c is not set and default is not implemented for {self.units = }')
     @eps_c.setter
     def eps_c(self, x):
+        if x is not None:
+            self._require_positive('eps_c', x)
         self._invalidate_section_caches()
         self._eps_c = x
         
@@ -430,6 +454,8 @@ class RC:
     @property
     def p0(self):
         # Nominal axial strength of section
+        self._require_positive('fc', self.fc)
+        self._require_positive('fy', self.fy)
         p0 = 0.85 * self.fc * (self.Ag - self.Asr) + self.fy * self.Asr
         return p0
 

--- a/src/libdenavit/section/RC.py
+++ b/src/libdenavit/section/RC.py
@@ -664,8 +664,8 @@ class RC:
             # As P -> 0 the clip returns min_I, the pure-bending limit.
             with np.errstate(divide='ignore', invalid='ignore'):
                 I_ACI = (0.8 + 25 * self.Asr / self.Ag) * (
-                        1 - M_arr / P_arr / self.depth(axis)
-                        - 0.5 * P_arr / self.p0) * Ig
+                        1 - np.abs(M_arr) / np.abs(P_arr) / self.depth(axis)
+                        - 0.5 * np.abs(P_arr) / self.p0) * Ig
             Ieff = np.clip(I_ACI, min_I, max_I)
             return self._match_load_shape(Ieff * Ec / creep_factor, scalar_input)
 

--- a/src/libdenavit/section/RC.py
+++ b/src/libdenavit/section/RC.py
@@ -17,7 +17,7 @@ class RC:
         self._eps_c = None
         self._Abt = None
         self._Mn = dict()
-        self._CS_id2d = None
+        self._CS_id2d = dict()
         self._reinforcement = None
 
         self.conc_cross_section = conc_cross_section
@@ -52,6 +52,7 @@ class RC:
         raise ValueError(f'Ec is not set and default is not implemented for {self.units = }')
     @Ec.setter
     def Ec(self, x):
+        self._invalidate_section_caches()
         self._Ec = x
 
     def get_shrinkage_props_for_uniaxial_material(self, print_factors=False, **kwargs):
@@ -299,6 +300,7 @@ class RC:
         raise ValueError(f'Es is not set and default is not implemented for {self.units = }')
     @Es.setter
     def Es(self, x):
+        self._invalidate_section_caches()
         self._Es = x
 
     @property
@@ -313,6 +315,7 @@ class RC:
         raise ValueError(f'eps_c is not set and default is not impleted for {self.units = }')
     @eps_c.setter
     def eps_c(self, x):
+        self._invalidate_section_caches()
         self._eps_c = x
         
 
@@ -338,6 +341,7 @@ class RC:
             raise ValueError('reinforcement must contain at least one reinforcement pattern')
 
         self._reinforcement = patterns
+        self._invalidate_section_caches()
 
     def depth(self, axis):
         return self.conc_cross_section.depth(axis)
@@ -607,12 +611,29 @@ class RC:
                 raise ValueError(f'Unknown EI_type {EI_type}')
 
     def interaction_diagram_object(self, axis, num_points=20, factored=False, only_compressive=True):
-        if self._CS_id2d is None:
+        # Cache on every input that changes the diagram. A single cached object
+        # returned the first diagram built for any later combination, so an
+        # x-axis request answered a y-axis one, and factored/only_compressive/
+        # num_points changes were ignored.
+        key = (axis, num_points, factored, only_compressive)
+        if key not in self._CS_id2d:
             from libdenavit import InteractionDiagram2d
             P_CS, M_CS, _ = self.section_interaction_2d(axis, num_points=num_points, factored=factored, only_compressive=only_compressive)
-            CS_id2d = InteractionDiagram2d(M_CS, P_CS, is_closed=True)
-            self._CS_id2d = CS_id2d
-        return self._CS_id2d
+            self._CS_id2d[key] = InteractionDiagram2d(M_CS, P_CS, is_closed=True)
+        return self._CS_id2d[key]
+
+    def _invalidate_section_caches(self):
+        """
+        Drop cached section responses after a change that alters them.
+
+        Only attributes exposed as properties can invalidate automatically.
+        fc, fy and conc_cross_section are plain public attributes, so mutating
+        them directly cannot be intercepted; call this method explicitly after
+        doing so. Converting them to properties is a larger API change and is
+        deliberately left out of this commit.
+        """
+        self._CS_id2d = dict()
+        self._Mn = dict()
 
     def Mn(self, axis):
         if self._Mn.get(axis) is None:

--- a/src/libdenavit/section/RC.py
+++ b/src/libdenavit/section/RC.py
@@ -774,21 +774,98 @@ class RC:
 
         return P, M, et
 
+    def _validate_confinement_inputs(self):
+        """
+        Validate the transverse reinforcement a confined concrete model needs.
+
+        Run before any confinement arithmetic so that missing or non-physical
+        input raises a clear error rather than a TypeError on None, a
+        ZeroDivisionError, or a silently inflated strength.
+        """
+        for name in ('dbt', 's', 'fyt'):
+            value = getattr(self, name)
+            if value is None:
+                raise ValueError(
+                    f"Confined concrete requires the transverse reinforcement property "
+                    f"'{name}' to be defined on the RC section. Set it via "
+                    f"RC(..., {name}=<value>), or use a '_no_confinement' conc_mat_type, "
+                    f"which does not require transverse reinforcement.")
+            if not np.isfinite(value) or value <= 0:
+                raise ValueError(
+                    f"Transverse reinforcement '{name}' must be a finite positive value "
+                    f"(got {value!r})")
+
+        if self.s <= self.dbt:
+            raise ValueError(
+                f'Hoop spacing s ({self.s}) must be greater than the transverse bar '
+                f'diameter dbt ({self.dbt}) so the clear spacing sp = s - dbt is positive.')
+
+        if not np.isfinite(self.fc) or self.fc <= 0:
+            raise ValueError(
+                f'fc must be a finite positive value for confined concrete (got {self.fc!r})')
+
+    @staticmethod
+    def _check_core_reinforcement_ratio(rho_cc):
+        """1 - rho_cc divides the confinement effectiveness coefficient."""
+        if not np.isfinite(rho_cc) or not 0.0 <= rho_cc < 1.0:
+            raise ValueError(
+                f'Longitudinal reinforcement ratio of the confined core is {rho_cc!r}; it '
+                f'must lie in [0, 1) because 1 - rho_cc appears in a denominator. Check the '
+                f'bar area, bar count and core dimensions.')
+
+    @staticmethod
+    def _check_confined_core(ke, *confining_stresses):
+        """ke must be positive, and each lateral stress is later divided by."""
+        if not np.isfinite(ke) or ke <= 0.0:
+            raise ValueError(
+                f'Confinement effectiveness coefficient ke is {ke!r}; this core geometry '
+                f'cannot produce a valid confined concrete model.')
+        for fl in confining_stresses:
+            if not np.isfinite(fl) or fl <= 0.0:
+                raise ValueError(
+                    f'Lateral confining stress is {fl!r}; it must be finite and positive. '
+                    f'Check the transverse bar area, spacing and yield strength.')
+
     def confined_concrete_props(self):
+        """
+        Confined concrete strength and strain.
+
+        Rectangles and circles follow Mander/Chang and Mander; the obround
+        applies the circular relations to the core enclosed by each perimeter
+        hoop, which is engineering judgement rather than a published model.
+        """
+        self._validate_confinement_inputs()
+
         if type(self.conc_cross_section).__name__ == 'Rectangle':
             # dc and bc = core dimensions to centerlines of perimeter hoop in x and y directions
-            bc = self.reinforcement[0].Bx + self.reinforcement[0].db / 2 + self.dbt / 2
-            dc = self.reinforcement[0].By + self.reinforcement[0].db / 2 + self.dbt / 2
+            reinf = self.reinforcement[0]
+            for count_name in ('nbx', 'nby'):
+                count = getattr(reinf, count_name)
+                if count < 2:
+                    raise ValueError(
+                        f'Confined rectangular sections need at least 2 bars per side; '
+                        f'{count_name} is {count}. The clear bar spacing is computed as '
+                        f'B/({count_name} - 1) - db.')
+
+            bc = reinf.Bx + reinf.db / 2 + self.dbt / 2
+            dc = reinf.By + reinf.db / 2 + self.dbt / 2
+            if bc <= 0 or dc <= 0:
+                raise ValueError(f'Confined core dimensions must be positive (bc = {bc}, dc = {dc})')
 
             # Ac = area of core of section enclosed by the center lines of the permiter hoops
             Ac = bc * dc
 
             # ρcc = ratio of area of longitudinal reinforcement to area of core of section
-            ρcc = self.reinforcement[0].Ab * self.reinforcement[0].num_bars / Ac
+            ρcc = reinf.Ab * reinf.num_bars / Ac
+            self._check_core_reinforcement_ratio(ρcc)
 
             # wx and wy = clear distance between bars in x and y directions
-            wx = self.reinforcement[0].Bx / (self.reinforcement[0].nbx - 1) - self.reinforcement[0].db
-            wy = self.reinforcement[0].By / (self.reinforcement[0].nby - 1) - self.reinforcement[0].db
+            wx = reinf.Bx / (reinf.nbx - 1) - reinf.db
+            wy = reinf.By / (reinf.nby - 1) - reinf.db
+            if wx < 0 or wy < 0:
+                raise ValueError(
+                    f'Clear distance between longitudinal bars is negative (wx = {wx:.4g}, '
+                    f'wy = {wy:.4g}); the bars do not fit in the core as specified.')
 
             # sp = clear vertical spacing between spiral or hoop bars
             sp = self.s - self.dbt
@@ -811,6 +888,7 @@ class RC:
             # flx and fly = lateral confining stress in x and y directions
             flx = ke * Asx / (self.s * dc) * self.fyt
             fly = ke * Asy / (self.s * bc) * self.fyt
+            self._check_confined_core(ke, flx, fly)
 
             # Confinement effect from Chang, G. A., and Mander, J. B. (1994).
             # Seismic Energy Based Fatigue Damage Analysis of Bridge Columns: Part I -
@@ -838,6 +916,7 @@ class RC:
 
             # ρcc = ratio of area of longitudinal reinforcement to area of core of section
             ρcc = self.reinforcement[0].Ab * self.reinforcement[0].num_bars / Ac
+            self._check_core_reinforcement_ratio(ρcc)
 
             # sp = clear vertical spacing between spiral or hoop bars
             sp = self.s - self.dbt
@@ -848,6 +927,7 @@ class RC:
             # flx and fly = lateral confining stress in x and y directions
             ρs = 4 * self.Abt / (ds * self.s)  # Equation 17
             fl = 0.5 * ke * ρs * self.fyt  # Equation 19
+            self._check_confined_core(ke, fl)
 
             # fcc = confined concrete strength
             fcc = self.fc * (-1.254 + 2.254 * sqrt(1 + 7.94 * fl / self.fc) - 2 * fl / self.fc)
@@ -868,6 +948,7 @@ class RC:
 
             # ρcc = ratio of area of longitudinal reinforcement to area of core of section
             ρcc = self.reinforcement[0].Ab * self.reinforcement[0].num_bars / 2 / Ac
+            self._check_core_reinforcement_ratio(ρcc)
 
             # sp = clear vertical spacing between spiral or hoop bars
             sp = self.s - self.dbt
@@ -878,6 +959,7 @@ class RC:
             # flx and fly = lateral confining stress in x and y directions
             ρs = 4 * self.Abt / (ds * self.s)  # Equation 17
             fl = 0.5 * ke * ρs * self.fyt  # Equation 19
+            self._check_confined_core(ke, fl)
 
             # fcc = confined concrete strength
             fcc = self.fc * (-1.254 + 2.254 * sqrt(1 + 7.94 * fl / self.fc) - 2 * fl / self.fc)
@@ -888,6 +970,10 @@ class RC:
             x_bar = (fl + fl) / (2 * self.fc)
             eps_prime_cc = self.eps_c * (1 + k2 * x_bar)
             return fcc, eps_prime_cc
+
+        raise ValueError(
+            f'No confined concrete model implemented for cross section type '
+            f'{type(self.conc_cross_section).__name__}')
 
     def build_ops_fiber_section(self, section_id, start_material_id, steel_mat_type, conc_mat_type, nfy, nfx, GJ=1.0e6,
                                 axis=None, creep=False, creep_props_dict=None, shrinkage_props_dict=None):
@@ -980,14 +1066,13 @@ class RC:
                 raise ValueError(f"Reinforcing pattern must be centered")
 
         def validate_confinement_reinf(self):
-            if self.dbt is None or self.s is None:
+            # Delegates so the transverse reinforcement, spacing and core
+            # geometry are checked identically wherever confinement is used.
+            try:
+                self._validate_confinement_inputs()
+            except ValueError as exc:
                 raise ValueError(
-                    f"conc_mat_type='{conc_mat_type}' models confined concrete and requires transverse "
-                    f"reinforcement to be defined on the RC section (dbt = transverse bar diameter, "
-                    f"s = spacing) to compute the confinement effect. "
-                    f"Set them via RC(..., dbt=<value>, s=<value>), or use a '_no_confinement' "
-                    f"conc_mat_type, which does not require transverse reinforcement."
-                )
+                    f"conc_mat_type='{conc_mat_type}' models confined concrete: {exc}") from exc
 
         confinement = False
 

--- a/src/libdenavit/section/RC.py
+++ b/src/libdenavit/section/RC.py
@@ -1138,21 +1138,21 @@ class RC:
                     warnings.warn("Default value of tcast (0) used for creep and shrinkage material")
 
             if confinement:
-                ops.uniaxialMaterial('CreepShrinkageACI209', cover_concrete_creep_material_id, cover_concrete_material_id,
-                                     self.tD, shrinkagedata['eps_sh_u'], shrinkagedata['psish'], self.Tcr,
-                                     creepdata['phi_u'], creepdata['psicr1'], creepdata['psicr2'], self.tcast)
-                
-                ops.uniaxialMaterial('CreepShrinkageACI209', core_concrete_creep_material_id, core_concrete_material_id,
-                                     self.tD, shrinkagedata['eps_sh_u'], shrinkagedata['psish'], self.Tcr,
-                                     creepdata['phi_u'], creepdata['psicr1'], creepdata['psicr2'], self.tcast)
+                creep_pairs = ((cover_concrete_creep_material_id, cover_concrete_material_id),
+                               (core_concrete_creep_material_id, core_concrete_material_id))
             else:
-                ops.uniaxialMaterial('CreepShrinkageACI209', concrete_creep_material_id, concrete_material_id,
+                creep_pairs = ((concrete_creep_material_id, concrete_material_id),)
+
+            for creep_material_id, base_material_id in creep_pairs:
+                ops.uniaxialMaterial('CreepShrinkageACI209', creep_material_id, base_material_id,
                                      self.tD, shrinkagedata['eps_sh_u'], shrinkagedata['psish'], self.Tcr,
                                      creepdata['phi_u'], creepdata['psicr1'], creepdata['psicr2'], self.tcast)
 
-            cover_concrete_material_id = cover_concrete_creep_material_id
-            core_concrete_material_id = core_concrete_creep_material_id
-            concrete_material_id = concrete_creep_material_id
+            if confinement:
+                cover_concrete_material_id = cover_concrete_creep_material_id
+                core_concrete_material_id = core_concrete_creep_material_id
+            else:
+                concrete_material_id = concrete_creep_material_id
         # endregion
 
         # region Define fibers and patches

--- a/src/libdenavit/section/RC.py
+++ b/src/libdenavit/section/RC.py
@@ -56,13 +56,23 @@ class RC:
         self._Ec = x
 
     def get_shrinkage_props_for_uniaxial_material(self, print_factors=False, **kwargs):
+        """
+        ACI 209R-92 shrinkage properties for the OpenSees CreepShrinkageACI209 material.
+
+        Input conventions, which the correction equations themselves fix:
+            RH              ambient relative humidity as a fraction, 0.4 to 1.0
+            fine_agg_ratio  fine aggregate by weight, in percent (50 means 50%)
+            air_content     air content in percentage points (6 means 6%)
+            VoverS          volume-to-surface ratio in length units
+            t0 / tc         age at loading / curing duration, days
+        """
         # Define default values for 'si' and 'us' units
         default_values = {'si':
                               {'eps_sh_u0': 780e-6,  # ultimate shrinkage strain
                                'tc': 7,  # initial moist curing time
                                'RH': 0.4,  # ambient relative humidity
                                'fine_agg_ratio': 50,  # fine aggregate ratio
-                               'air_content': 0.06,  # air content
+                               'air_content': 6,  # air content, percentage points
                                'VoverS': 38,  # volume to surface ratio
                                'slump': 70,  # slump (mm)
                                'cement_content': 360  # cement content (kg/m^3)
@@ -72,7 +82,7 @@ class RC:
                                'tc': 7,  # initial moist curing time
                                'RH': 0.4,  # ambient relative humidity
                                'fine_agg_ratio': 50,  # fine aggregate ratio
-                               'air_content': 0.06,  # air content
+                               'air_content': 6,  # air content, percentage points
                                'VoverS': 1.5,  # volume to surface ratio
                                'slump': 2.7,  # slump (in)
                                'cement_content': 611  # cement content (lb/yd^3)
@@ -175,6 +185,16 @@ class RC:
         return {'eps_sh_u': eps_sh_u, 'f': f, 'psish': f}
 
     def get_creep_props_for_uniaxial_material(self, print_factors=False, **kwargs):
+        """
+        ACI 209R-92 creep properties for the OpenSees CreepShrinkageACI209 material.
+
+        Input conventions, which the correction equations themselves fix:
+            RH              ambient relative humidity as a fraction, 0.4 to 1.0
+            fine_agg_ratio  fine aggregate by weight, in percent (50 means 50%)
+            air_content     air content in percentage points (6 means 6%)
+            VoverS          volume-to-surface ratio in length units
+            t0 / tc         age at loading / curing duration, days
+        """
         # Define default values for 'si' and 'us' units
         default_values = {'si':
                               {'phi_u_0': 2.35,  # ultimate creep coefficient
@@ -182,8 +202,8 @@ class RC:
                                'RH': 0.4,  # ambient relative humidity
                                'VoverS': 38,  # volume to surface ratio
                                'slump': 70,  # slump (mm)
-                               'fine_agg_ratio': 50,  # fine aggregate ratio
-                               'air_content': 0.06,  # air content
+                               'fine_agg_ratio': 50,  # fine aggregate ratio, percent by weight
+                               'air_content': 6,  # air content, percentage points
                                },
                           'us':
                               {'phi_u_0': 2.35,  # ultimate creep coefficient
@@ -191,8 +211,8 @@ class RC:
                                'RH': 0.4,  # ambient relative humidity
                                'VoverS': 1.5,  # volume to surface ratio
                                'slump': 2.7,  # slump (mm)
-                               'fine_agg_ratio': 0.5,  # fine aggregate ratio
-                               'air_content': 0.06,  # air content
+                               'fine_agg_ratio': 50,  # fine aggregate ratio, percent by weight
+                               'air_content': 6,  # air content, percentage points
                                }
                           }
 

--- a/src/libdenavit/sway_column_2d.py
+++ b/src/libdenavit/sway_column_2d.py
@@ -11,7 +11,11 @@ from libdenavit.analysis_helpers import try_analysis_options, ops_get_section_st
 from libdenavit.column_2d import Column2d
 
 
-class SwayColumn2d(Column2d):   
+class SwayColumn2d(Column2d):
+
+    _INIT_KWARGS = Column2d._INIT_KWARGS | {
+        'Dxo', 'effective_length_factor_override',
+    }
     def __init__(self, section, length, k_bot, k_top, gamma, **kwargs):
         """
             Represents a sway 2D column
@@ -29,8 +33,8 @@ class SwayColumn2d(Column2d):
                           Dxo (float, optional): Lateral displacement at the top. Default is 0.0.
                           effective_length_factor_override (float or None, optional): Override for effective length factor. Default is None.
                           axis (str, optional): Axis. Default is None.
-                          n_elem (int, optional): Number of elements for OpenSees analysis. Default is 8.
-                          element_type (str, optional): Type of OpenSees element. Default is 'mixedBeamColumn'.
+                          ops_n_elem (int, optional): Number of elements for OpenSees analysis. Default is 8.
+                          ops_element_type (str, optional): Type of OpenSees element. Default is 'mixedBeamColumn'.
                           ops_geom_transf_type (str, optional): OpenSees geometric transformation type. Default is 'Corotational'.
                           ops_integration_points (int, optional): Number of integration points for OpenSees analysis. Default is 3.
         """

--- a/src/libdenavit/sway_column_2d.py
+++ b/src/libdenavit/sway_column_2d.py
@@ -95,14 +95,6 @@ class SwayColumn2d(Column2d):
             raise ValueError(f'lever_arm not implemented for k_bot = {self.k_bot} and k_top = {self.k_top}')
 
 
-    def _initialize_results(self):
-        """Initialize analysis results object with required attributes."""
-        # Get base attributes and add Sway-specific ones
-        results = super()._initialize_results()
-        # Add Sway-specific attributes
-        for attr in ['applied_horizontal_load', 'moment_at_top', 'moment_at_bottom']:
-            setattr(results, attr, [])
-        return results
 
 
     def build_ops_model(self, section_id, section_args, section_kwargs, **kwargs):
@@ -174,10 +166,6 @@ class SwayColumn2d(Column2d):
             ops.element(self.ops_element_type, index, index, index + 1, 100, 1)
 
 
-    def _set_limit_point_values(self, results, ind, x):
-        """Override to include horizontal load values."""
-        super()._set_limit_point_values(results, ind, x)
-        results.applied_horizontal_load_at_limit_point = interpolate_list(results.applied_horizontal_load, ind, x)
 
 
     def run_ops_interaction(self, **kwargs):
@@ -797,15 +785,6 @@ class SwayColumn2d(Column2d):
                 "EIgross": EIgross}
 
 
-    def _extract_analysis_config(self, **kwargs):
-        """Override to adjust default values for sway analysis."""
-        config = super()._extract_analysis_config(**kwargs)
-        # Adjust defaults for sway analysis if not explicitly provided
-        if 'num_steps_vertical' not in kwargs:
-            config['num_steps_vertical'] = 10
-        if 'disp_incr_factor' not in kwargs:
-            config['disp_incr_factor'] = 5e-05
-        return config
     
     
         

--- a/src/libdenavit/sway_column_2d.py
+++ b/src/libdenavit/sway_column_2d.py
@@ -76,6 +76,13 @@ class SwayColumn2d(Column2d):
         return config
 
 
+    def _peak_response(self, results, analysis_type=None):
+        """A nonproportional sway analysis is driven by the horizontal load, not the axial."""
+        if analysis_type is not None and analysis_type.lower() == 'nonproportional_limit_point':
+            return results.applied_horizontal_load, max(results.applied_horizontal_load)
+        return results.applied_axial_load, max(results.applied_axial_load)
+
+
     @property
     def lever_arm(self):
         if self.k_bot == 0 and self.k_top > 0:
@@ -801,30 +808,5 @@ class SwayColumn2d(Column2d):
         return config
     
     
-    def _find_limit_point(self, results, config, analysis_type):
-        """Find and set limit point values with sway-specific logic."""
-        if 'Analysis Failed' in results.exit_message:
-            if analysis_type.lower() == 'proportional_limit_point':
-                ind, x = find_limit_point_in_list(results.applied_axial_load, max(results.applied_axial_load))
-            elif analysis_type.lower() == 'nonproportional_limit_point':
-                ind, x = find_limit_point_in_list(results.applied_horizontal_load, max(results.applied_horizontal_load))
-            warnings.warn('Analysis failed')
-        elif 'Eigenvalue Limit' in results.exit_message:
-            ind, x = find_limit_point_in_list(results.lowest_eigenvalue, config['eigenvalue_limit'])
-        elif 'Extreme Compressive Concrete Fiber Strain Limit Reached' in results.exit_message:
-            ind, x = find_limit_point_in_list(results.maximum_concrete_compression_strain, config['concrete_strain_limit'])
-        elif 'Extreme Steel Fiber Strain Limit Reached' in results.exit_message:
-            ind, x = find_limit_point_in_list(results.maximum_steel_strain, config['steel_strain_limit'])
-        elif 'Deformation Limit Reached' in results.exit_message:
-            ind, x = find_limit_point_in_list(results.maximum_abs_disp, config['deformation_limit'])
-        elif 'Load Drop Limit Reached' in results.exit_message:
-            if analysis_type.lower() == 'proportional_limit_point':
-                ind, x = find_limit_point_in_list(results.applied_axial_load, max(results.applied_axial_load))
-            elif analysis_type.lower() == 'nonproportional_limit_point':
-                ind, x = find_limit_point_in_list(results.applied_horizontal_load, max(results.applied_horizontal_load))
-        else:
-            raise Exception('Unknown limit point')
-
-        self._set_limit_point_values(results, ind, x)
         
     

--- a/src/libdenavit/sway_column_2d.py
+++ b/src/libdenavit/sway_column_2d.py
@@ -161,6 +161,8 @@ class SwayColumn2d(Column2d):
 
         if type(self.section).__name__ == "RC":
             self.section.build_ops_fiber_section(section_id, *section_args, **section_kwargs, axis=self.axis)
+        elif type(self.section).__name__ == "I_shape":
+            self.section.build_ops_fiber_section(section_id, *section_args, **section_kwargs, axis=self.axis)
         else:
             raise ValueError(f'Unknown cross section type {type(self.section).__name__}')
 
@@ -318,8 +320,12 @@ class SwayColumn2d(Column2d):
             results.lowest_eigenvalue.append(ops.eigen('-fullGenLapack', 1)[0])
             results.moment_at_top.append(ops.eleForce(self.ops_n_elem - 1, 6))
             results.moment_at_bottom.append(ops.eleForce(0, 3))
-            results.maximum_concrete_compression_strain.append(section_strains[0])
-            results.maximum_steel_strain.append(section_strains[1])
+            if type(self.section).__name__ == "RC":
+                results.maximum_concrete_compression_strain.append(section_strains[0])
+                results.maximum_steel_strain.append(section_strains[1])
+            elif type(self.section).__name__ == "I_shape":
+                results.maximum_compression_strain.append(section_strains[0])
+                results.maximum_tensile_strain.append(section_strains[1])
             if self.axis == 'x':
                 results.curvature.append(section_strains[2])
             elif self.axis == 'y':
@@ -433,8 +439,12 @@ class SwayColumn2d(Column2d):
             results.lowest_eigenvalue.append(ops.eigen('-fullGenLapack', 1)[0])
             results.moment_at_top.append(ops.eleForce(self.ops_n_elem - 1, 6))
             results.moment_at_bottom.append(ops.eleForce(0, 3))
-            results.maximum_concrete_compression_strain.append(section_strains[0])
-            results.maximum_steel_strain.append(section_strains[1])
+            if type(self.section).__name__ == "RC":
+                results.maximum_concrete_compression_strain.append(section_strains[0])
+                results.maximum_steel_strain.append(section_strains[1])
+            elif type(self.section).__name__ == "I_shape":
+                results.maximum_compression_strain.append(section_strains[0])
+                results.maximum_tensile_strain.append(section_strains[1])
             if self.axis == 'x':
                 results.curvature.append(section_strains[2])
             elif self.axis == 'y':
@@ -484,8 +494,12 @@ class SwayColumn2d(Column2d):
             results.lowest_eigenvalue.append(ops.eigen('-fullGenLapack', 1)[0])
             results.moment_at_top.append(ops.eleForce(self.ops_n_elem - 1, 6))
             results.moment_at_bottom.append(ops.eleForce(0, 3))
-            results.maximum_concrete_compression_strain.append(section_strains[0])
-            results.maximum_steel_strain.append(section_strains[1])
+            if type(self.section).__name__ == "RC":
+                results.maximum_concrete_compression_strain.append(section_strains[0])
+                results.maximum_steel_strain.append(section_strains[1])
+            elif type(self.section).__name__ == "I_shape":
+                results.maximum_compression_strain.append(section_strains[0])
+                results.maximum_tensile_strain.append(section_strains[1])
             if self.axis == 'x':
                 results.curvature.append(section_strains[2])
             elif self.axis == 'y':

--- a/src/libdenavit/sway_column_2d.py
+++ b/src/libdenavit/sway_column_2d.py
@@ -651,24 +651,27 @@ class SwayColumn2d(Column2d):
             iP = 0.999 * P_list[0] * (num_points - i - 1) / (num_points - 1)
             iM2_section = id2d.find_x_given_y(iP, 'pos')
 
-            EIeff = self.section.EIeff(self.axis, EI_type, beta_dns, P=iP, M=iM2_section, col=self)
-            k = self.effective_length_factor(EIeff)
-            Pc = pi ** 2 * EIeff / (k * self.length) ** 2
-
-            iM1_list = [0]
-            iM2_list = np.arange(0, iM2_section, iM2_section / 1000)
-
-            for iM2 in iM2_list:
-                EIeff = self.section.EIeff(self.axis, EI_type, beta_dns, P=iP, M=iM2, col=self)
+            trials = []
+            for iM1_trial in np.linspace(0.0, iM2_section, 1000):
+                EIeff = self.section.EIeff(self.axis, EI_type, beta_dns, P=iP, M=iM1_trial, col=self)
                 k = self.effective_length_factor(EIeff)
                 Pc = pi ** 2 * EIeff / (k * self.length) ** 2
-                if Pc_factor * Pc < iP:
-                    break
-                delta_s = max(1 / (1 - (iP) / (Pc_factor * Pc)), 1.0)
-                iM1_list.append(iM2 / delta_s)
+                if Pc_factor * Pc <= iP:
+                    # Unstable at this moment, so there is no valid magnifier. Skip
+                    # rather than stop: EIeff is not monotonic in moment for every
+                    # EI_type, so a larger moment can be stable again.
+                    continue
+                delta_s = max(1 / (1 - iP / (Pc_factor * Pc)), 1.0)
+                iM2_trial = delta_s * iM1_trial
 
-            iM1 = max(iM1_list)
-            iM2 = iM2_list[iM1_list.index(iM1) -1]
+                # The magnified moment still has to fit inside the section.
+                if iM2_trial <= iM2_section:
+                    trials.append((iM1_trial, iM2_trial))
+
+            if trials:
+                iM1, iM2 = max(trials, key=lambda trial: trial[0])
+            else:
+                iM1, iM2 = 0.0, 0.0
             P_list.append(iP)
             M1_list.append(iM1)
             M2_list.append(iM2)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,11 +71,15 @@ class OpsRecorder:
         self.fibers = []
         self.layers = []
         self.patches = []
+        self.materials = []
 
     def __getattr__(self, name):
         def noop(*args, **kwargs):
             return None
         return noop
+
+    def uniaxialMaterial(self, kind, tag, *args):
+        self.materials.append({'kind': kind, 'tag': tag, 'args': args})
 
     def fiber(self, y, z, area, material):
         self.fibers.append((y, z, area, material))
@@ -96,6 +100,20 @@ class OpsRecorder:
         so discretisation tests must count both.
         """
         return len(self.fibers) + sum(layer['n'] for layer in self.layers)
+
+    @property
+    def defined_material_tags(self):
+        return {m['tag'] for m in self.materials}
+
+    @property
+    def used_material_tags(self):
+        tags = {f[3] for f in self.fibers}
+        tags |= {layer['material'] for layer in self.layers}
+        tags |= {p[1] for p in self.patches if len(p) > 1}
+        return tags
+
+    def materials_of(self, kind):
+        return [m for m in self.materials if m['kind'] == kind]
 
     @property
     def steel_positions(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,147 @@
+"""Shared pytest fixtures and helpers for the libdenavit test suite.
+
+Tests import libdenavit from ``src`` so they exercise the working tree rather
+than any copy installed into site-packages.
+"""
+import sys
+from pathlib import Path
+
+SRC = Path(__file__).resolve().parents[1] / 'src'
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+import pytest  # noqa: E402
+
+from libdenavit.section import (  # noqa: E402
+    RC, Rectangle, Circle, Obround, ReinfRect, ReinfCirc, ReinfIntersectingLoops,
+)
+
+
+# --- section builders -------------------------------------------------------
+
+def make_rect(confined=False, **kwargs):
+    reinf = ReinfRect(14, 24, 3, 3, 0.79)
+    reinf.db = 1.0
+    extra = dict(dbt=0.5, s=4, fyt=60) if confined else {}
+    extra.update(kwargs)
+    return RC(Rectangle(30, 20), reinf, 4, 60, 'US', **extra)
+
+
+def make_circle(confined=False, num_bars=8, **kwargs):
+    reinf = ReinfCirc(9, num_bars, 0.79)
+    reinf.db = 1.0
+    extra = dict(dbt=0.5, s=4, fyt=60) if confined else {}
+    extra.update(kwargs)
+    return RC(Circle(24), reinf, 4, 60, 'US', **extra)
+
+
+def make_obround(confined=False, **kwargs):
+    reinf = ReinfIntersectingLoops(20, 12, 8, 0.79)
+    reinf.db = 1.0
+    extra = dict(dbt=0.5, s=4, fyt=60) if confined else {}
+    extra.update(kwargs)
+    return RC(Obround(24, 12), reinf, 4, 60, 'US', **extra)
+
+
+@pytest.fixture
+def rect():
+    return make_rect()
+
+
+@pytest.fixture
+def circle():
+    return make_circle()
+
+
+@pytest.fixture
+def obround():
+    return make_obround()
+
+
+# --- OpenSees call recorder -------------------------------------------------
+
+class OpsRecorder:
+    """Stand-in for the opensees module that records fiber geometry calls.
+
+    build_ops_fiber_section talks to OpenSees imperatively, so the only way to
+    assert on the geometry it generates is to capture the calls.
+    """
+
+    def __init__(self):
+        self.fibers = []
+        self.layers = []
+        self.patches = []
+
+    def __getattr__(self, name):
+        def noop(*args, **kwargs):
+            return None
+        return noop
+
+    def fiber(self, y, z, area, material):
+        self.fibers.append((y, z, area, material))
+
+    def layer(self, kind, material, n, area, *coords):
+        self.layers.append({'kind': kind, 'material': material, 'n': n,
+                            'area': area, 'coords': coords})
+
+    def patch(self, *args):
+        self.patches.append(args)
+
+    # -- derived views --
+    @property
+    def total_fibers(self):
+        """Fibers from direct calls plus those a layer expands into.
+
+        Rectangles emit concrete through layer(), other shapes through fiber(),
+        so discretisation tests must count both.
+        """
+        return len(self.fibers) + sum(layer['n'] for layer in self.layers)
+
+    @property
+    def steel_positions(self):
+        """Positions of the positive-area (reinforcing bar) fibers."""
+        return sorted({round(f[0], 9) for f in self.fibers if f[2] > 0})
+
+    def layer_fibers(self):
+        """(position, area) for every fiber implied by the recorded layers.
+
+        OpenSees places the first and last fiber of a straight layer exactly at
+        the supplied endpoints, verified against a zeroLengthSection.
+        """
+        import numpy as np
+        out = []
+        for layer in self.layers:
+            c = layer['coords']
+            n = layer['n']
+            if n > 1:
+                positions = np.linspace(c[0], c[2], n)
+            else:
+                positions = np.array([(c[0] + c[2]) / 2])
+            out.extend((p, layer['area']) for p in positions)
+        return out
+
+
+@pytest.fixture
+def record_section():
+    """Build a fiber section against a recorder and return the recorder."""
+    import importlib
+
+    importlib.import_module('libdenavit.section.RC')
+    rc_module = sys.modules['libdenavit.section.RC']
+    fiber_module = importlib.import_module('libdenavit.OpenSees.fiber_section')
+
+    def _record(section, axis, nfy=20, nfx=20,
+                conc_mat_type='Concrete04_no_confinement', **kwargs):
+        recorder = OpsRecorder()
+        saved_rc, saved_fiber = rc_module.ops, fiber_module.ops
+        rc_module.ops = recorder
+        fiber_module.ops = recorder
+        try:
+            section.build_ops_fiber_section(
+                1, 1, 'ElasticPP', conc_mat_type, nfy, nfx, axis=axis, **kwargs)
+        finally:
+            rc_module.ops = saved_rc
+            fiber_module.ops = saved_fiber
+        return recorder
+
+    return _record

--- a/tests/test_interaction_diagram_2d.py
+++ b/tests/test_interaction_diagram_2d.py
@@ -1,0 +1,92 @@
+"""Regression tests for InteractionDiagram2d.find_x_given_y."""
+import numpy as np
+import pytest
+
+from libdenavit import InteractionDiagram2d
+
+
+# A notched outline: the right flank runs out to x = 10, cuts back in toward
+# x = 2, then bulges out again, so a horizontal line through the notch meets the
+# boundary more than once. Points are listed in polar-angle order because the
+# constructor sorts them that way.
+NOTCHED_X = [10.0, 9.0, 2.0, 7.0, 5.0, 0.0, -5.0, -8.0, -9.0, 0.0, 6.0]
+NOTCHED_Y = [0.0, 1.5, 3.0, 4.5, 6.5, 9.0, 7.0, 3.0, -2.0, -6.0, -3.0]
+
+# A convex diamond, where every horizontal line meets the boundary once on each
+# side. Behaviour here must be unchanged by the fix.
+DIAMOND_X = [10.0, 0.0, -10.0, 0.0]
+DIAMOND_Y = [0.0, 10.0, 0.0, -10.0]
+
+
+@pytest.fixture
+def notched():
+    return InteractionDiagram2d(NOTCHED_X, NOTCHED_Y, is_closed=True)
+
+
+@pytest.fixture
+def diamond():
+    return InteractionDiagram2d(DIAMOND_X, DIAMOND_Y, is_closed=True)
+
+
+def crossings_at(diagram, y, peak):
+    """Every x where the horizontal line at y meets the boundary."""
+    path_x = np.linspace(0, peak, 10)
+    path_y = y * np.ones(10)
+    found = diagram.find_intersection(path_x, path_y)[0]
+    return np.atleast_1d(np.asarray(found, dtype=float))
+
+
+class TestMultipleCrossings:
+    """The defect: a list came back where a number was expected."""
+
+    @pytest.mark.parametrize('y', [3.0, 3.5, 4.5, 5.5, 6.5])
+    def test_returns_a_scalar(self, notched, y):
+        value = notched.find_x_given_y(y, '+')
+        assert isinstance(value, float)
+        assert not isinstance(value, (list, tuple, np.ndarray))
+
+    @pytest.mark.parametrize('y', [3.0, 3.5, 4.5, 5.5, 6.5])
+    def test_returns_the_outermost_crossing(self, notched, y):
+        # Guard: these y values must actually produce the ambiguity, otherwise
+        # the test would pass without exercising the fix at all.
+        found = crossings_at(notched, y, 1.1 * max(NOTCHED_X))
+        assert found.size > 1
+
+        assert notched.find_x_given_y(y, '+') == pytest.approx(found.max())
+
+    def test_known_value_through_the_notch(self, notched):
+        # At y = 3 the line meets the boundary at x = 2 (the notch) and x = 8.
+        # The capacity is the outer one.
+        assert notched.find_x_given_y(3.0, '+') == pytest.approx(8.0)
+
+    def test_result_supports_arithmetic(self, notched):
+        # This is the operation that used to raise: run_AASHTO_interaction
+        # divides the returned value by a float.
+        assert notched.find_x_given_y(3.0, '+') / 2.0 == pytest.approx(4.0)
+
+    def test_negative_direction_returns_the_most_negative(self, notched):
+        found = crossings_at(notched, 1.0, 1.1 * min(NOTCHED_X))
+        value = notched.find_x_given_y(1.0, '-')
+        assert isinstance(value, float)
+        assert value == pytest.approx(found.min())
+
+
+class TestSingleCrossing:
+    """The convex case must be untouched by the fix."""
+
+    @pytest.mark.parametrize('y, expected', [(0.0, 10.0), (5.0, 5.0), (-5.0, 5.0)])
+    def test_positive_direction(self, diamond, y, expected):
+        assert diamond.find_x_given_y(y, str('+')) == pytest.approx(expected)
+
+    @pytest.mark.parametrize('y, expected', [(0.0, -10.0), (5.0, -5.0)])
+    def test_negative_direction(self, diamond, y, expected):
+        assert diamond.find_x_given_y(y, '-') == pytest.approx(expected)
+
+    def test_returns_scalar(self, diamond):
+        assert isinstance(diamond.find_x_given_y(5.0, '+'), float)
+
+
+class TestArgumentValidation:
+    def test_rejects_unknown_direction(self, diamond):
+        with pytest.raises(ValueError, match='signX must be positive or negative'):
+            diamond.find_x_given_y(5.0, 'sideways')

--- a/tests/test_non_sway_column_2d.py
+++ b/tests/test_non_sway_column_2d.py
@@ -1,0 +1,106 @@
+"""Tests for the effective stiffness argument of the ACI elastic analysis.
+
+run_aci_elastic_second_order_analysis builds a single Elastic section before
+loading starts, so its stiffness has to be constant. These tests pin down how
+that constant is chosen: the historical hardcoded default, the load-independent
+built-in methods, an explicit constant, and a callable.
+"""
+import numpy as np
+import pytest
+
+from conftest import make_rect
+
+from libdenavit import NonSwayColumn2d
+
+
+ANALYSIS_KWARGS = dict(
+    analysis_type='proportional_limit_point',
+    P=100.0,
+    e=1.0,
+    section_id=1,
+    disp_incr_factor=1e-5,
+    num_steps_vertical=100,
+    max_1_4_Mu_limit=False,
+    section_factored=True,
+)
+
+
+@pytest.fixture
+def column():
+    return NonSwayColumn2d(section=make_rect(), length=240.0, et=2.0, eb=2.0,
+                           axis='x', apply_minimum_eccentricity=False)
+
+
+def run(column, **kwargs):
+    results = column.run_aci_elastic_second_order_analysis(
+        **ANALYSIS_KWARGS, **kwargs)
+    return results.applied_axial_load_at_limit_point
+
+
+def test_default_stiffness_is_the_historical_hardcoded_value(column):
+    """Callers that pass nothing must see the pre-existing behaviour."""
+    section = column.section
+    historical = 0.875 * (0.2 * section.Ec * section.Ig('x')
+                          + section.Es * section.Isr('x'))
+    assert run(column) == pytest.approx(run(column, EI=historical))
+
+
+def test_explicit_EI_changes_the_result(column):
+    section = column.section
+    EcIg = section.Ec * section.Ig('x')
+    assert run(column, EI=0.3 * EcIg) != pytest.approx(run(column, EI=0.8 * EcIg))
+
+
+def test_capacity_increases_with_stiffness(column):
+    """A stiffer member buckles later, so capacity must be non-decreasing."""
+    section = column.section
+    EcIg = section.Ec * section.Ig('x')
+    capacities = [run(column, EI=gamma * EcIg)
+                  for gamma in (0.3, 0.4, 0.6, 0.8)]
+    assert np.all(np.diff(capacities) > 0)
+
+
+def test_callable_EI_matches_the_constant_it_returns(column):
+    section = column.section
+    EcIg = section.Ec * section.Ig('x')
+    assert run(column, EI=lambda **kwargs: 0.6 * EcIg) == pytest.approx(
+        run(column, EI=0.6 * EcIg))
+
+
+def test_callable_EI_receives_the_section_and_extra_kwargs(column):
+    seen = {}
+
+    def stiffness(section=None, axis=None, factor=None, **kwargs):
+        seen.update(section=section, axis=axis, factor=factor)
+        return factor * section.Ec * section.Ig(axis)
+
+    run(column, EI=stiffness, EI_kwargs={'factor': 0.5})
+    assert seen['section'] is column.section
+    assert seen['axis'] == 'x'
+    assert seen['factor'] == 0.5
+
+
+@pytest.mark.parametrize('EI_type', ['aci-a', 'aci-b', 'gross'])
+def test_load_independent_EI_types_match_EIeff(column, EI_type):
+    expected = column.section.EIeff('x', EI_type)
+    assert run(column, EI_type=EI_type) == pytest.approx(
+        run(column, EI=expected))
+
+
+@pytest.mark.parametrize(
+    'EI_type', ['aci-c', 'jf-a', 'jf-b', 'proposed_1_1', 'proposed_1_2',
+                'proposed_2', 'ACI-C', ' aci-c '])
+def test_load_dependent_EI_types_are_rejected(column, EI_type):
+    """The stiffness is fixed before P is known, so these cannot be honoured."""
+    with pytest.raises(ValueError, match='depends on the applied load'):
+        run(column, EI_type=EI_type)
+
+
+def test_non_positive_EI_is_rejected(column):
+    with pytest.raises(ValueError):
+        run(column, EI=0.0)
+
+
+def test_non_finite_EI_is_rejected(column):
+    with pytest.raises(ValueError):
+        run(column, EI=float('nan'))

--- a/tests/test_rc_section.py
+++ b/tests/test_rc_section.py
@@ -641,3 +641,33 @@ class TestCustomEIeff:
     def test_unknown_string_lists_the_builtins(self, rect):
         with pytest.raises(ValueError, match='aci-a'):
             rect.EIeff('x', 'no-such-method')
+
+
+class TestMaterialPropertyValidation:
+    """A non-physical modulus used to propagate into a negative EIgross."""
+
+    @pytest.mark.parametrize('bad', [0, -4])
+    def test_invalid_fc_rejected(self, bad):
+        section = RC(Rectangle(30, 20), ReinfRect(14, 24, 3, 3, 0.79), bad, 60, 'US')
+        with pytest.raises(ValueError, match='fc must be a finite positive'):
+            section.Ec
+
+    def test_invalid_fy_rejected(self):
+        section = RC(Rectangle(30, 20), ReinfRect(14, 24, 3, 3, 0.79), 4, -60, 'US')
+        with pytest.raises(ValueError, match='fy must be a finite positive'):
+            section.p0
+
+    @pytest.mark.parametrize('attribute', ['Ec', 'Es', 'eps_c'])
+    @pytest.mark.parametrize('bad', [0, -1000, float('nan'), float('inf')])
+    def test_invalid_modulus_rejected(self, rect, attribute, bad):
+        with pytest.raises(ValueError, match='finite positive'):
+            setattr(rect, attribute, bad)
+
+    @pytest.mark.parametrize('attribute,value',
+                             [('Ec', 4000.0), ('Es', 29500.0), ('eps_c', 0.0021)])
+    def test_valid_values_still_accepted(self, rect, attribute, value):
+        setattr(rect, attribute, value)
+        assert getattr(rect, attribute) == value
+
+    def test_gross_stiffness_stays_positive(self, rect):
+        assert rect.EIgross('x') > 0

--- a/tests/test_rc_section.py
+++ b/tests/test_rc_section.py
@@ -392,3 +392,67 @@ class TestEndToEnd:
         _, Mx, _ = section.section_interaction_2d('x', 8)
         _, My, _ = section.section_interaction_2d('y', 8)
         assert not np.allclose(Mx, My), 'a 30x20 section is not axis-symmetric'
+
+
+class TestMaterialConstruction:
+    """Material ids, wrapper bases and argument ordering."""
+
+    CASES = [(False, 'Concrete04_no_confinement'), (True, 'Concrete04')]
+
+    @pytest.mark.parametrize('confined,conc', CASES)
+    @pytest.mark.parametrize('creep', [False, True])
+    def test_every_used_material_is_defined(self, record_section, confined, conc, creep):
+        rec = record_section(make_rect(confined=confined), 'x',
+                             conc_mat_type=conc, creep=creep)
+        assert rec.used_material_tags <= rec.defined_material_tags
+
+    @pytest.mark.parametrize('confined,conc', CASES)
+    def test_creep_wrappers_reference_defined_bases(self, record_section, confined, conc):
+        rec = record_section(make_rect(confined=confined), 'x',
+                             conc_mat_type=conc, creep=True)
+        wrappers = rec.materials_of('CreepShrinkageACI209')
+        assert wrappers, 'creep=True must define wrapper materials'
+        for wrapper in wrappers:
+            base = wrapper['args'][0]      # first argument is the wrapped material
+            assert base in rec.defined_material_tags
+            assert base != wrapper['tag'], 'a wrapper must not wrap itself'
+
+    @pytest.mark.parametrize('confined,conc', CASES)
+    def test_creep_and_non_creep_use_distinct_ids(self, record_section, confined, conc):
+        plain = record_section(make_rect(confined=confined), 'x', conc_mat_type=conc)
+        crept = record_section(make_rect(confined=confined), 'x',
+                               conc_mat_type=conc, creep=True)
+        assert crept.used_material_tags != plain.used_material_tags
+        assert len({m['tag'] for m in crept.materials}) == len(crept.materials), \
+            'each material id may only be defined once'
+
+    def test_confined_creep_wraps_cover_and_core_separately(self, record_section):
+        rec = record_section(make_rect(confined=True), 'x',
+                             conc_mat_type='Concrete04', creep=True)
+        bases = [w['args'][0] for w in rec.materials_of('CreepShrinkageACI209')]
+        assert len(bases) == 2 and len(set(bases)) == 2
+
+    def test_unconfined_creep_defines_one_wrapper(self, record_section):
+        rec = record_section(make_rect(), 'x',
+                             conc_mat_type='Concrete04_no_confinement', creep=True)
+        assert len(rec.materials_of('CreepShrinkageACI209')) == 1
+
+    def test_confined_core_is_stronger_than_cover(self, record_section):
+        """Cover uses fc, core uses the confined fcc; both compression negative."""
+        rec = record_section(make_rect(confined=True), 'x', conc_mat_type='Concrete04')
+        strengths = [m['args'][0] for m in rec.materials_of('Concrete04')]
+        assert len(strengths) == 2
+        assert all(f < 0 for f in strengths), 'compression must be negative'
+        assert min(strengths) < max(strengths), 'core must exceed cover in magnitude'
+
+    @pytest.mark.parametrize('conc_mat_type', [
+        'Concrete04_no_confinement', 'Concrete01_no_confinement', 'ENT', 'Elastic',
+    ])
+    def test_unconfined_material_types_build(self, record_section, conc_mat_type):
+        rec = record_section(make_rect(), 'x', conc_mat_type=conc_mat_type)
+        assert rec.materials and (rec.fibers or rec.layers)
+
+    @pytest.mark.parametrize('factory', [make_rect, make_circle, make_obround])
+    def test_confined_material_builds_for_every_shape(self, record_section, factory):
+        rec = record_section(factory(confined=True), 'x', conc_mat_type='Concrete04')
+        assert len(rec.materials_of('Concrete04')) == 2, 'cover and core'

--- a/tests/test_rc_section.py
+++ b/tests/test_rc_section.py
@@ -543,3 +543,101 @@ class TestEIeffNormalization:
     @pytest.mark.parametrize('betadns', [0.0, 0.6, -0.5])
     def test_valid_betadns_gives_positive_stiffness(self, rect, betadns):
         assert rect.EIeff('x', 'aci-a', betadns) > 0
+
+
+class TestCustomEIeff:
+    """Constant and callable user supplied stiffness."""
+
+    @staticmethod
+    def _custom(section, axis, betadns, P, M, col, reduction=0.45):
+        return reduction * section.Ec * section.Ig(axis) / (1.0 + betadns)
+
+    def test_constant(self, rect):
+        assert rect.EIeff('x', EI=1.25e8) == pytest.approx(1.25e8)
+
+    def test_numpy_scalar_constant(self, rect):
+        assert rect.EIeff('x', EI=np.float64(1.25e8)) == pytest.approx(1.25e8)
+
+    def test_non_string_EI_type_is_custom(self, rect):
+        assert rect.EIeff('x', 1.25e8) == pytest.approx(1.25e8)
+
+    def test_callable(self, rect):
+        expected = 0.45 * rect.Ec * rect.Ig('x')
+        assert rect.EIeff('x', P=100.0, M=500.0,
+                          EI=self._custom) == pytest.approx(expected)
+
+    def test_callable_with_kwargs(self, rect):
+        expected = 0.50 * rect.Ec * rect.Ig('x')
+        got = rect.EIeff('x', P=100.0, M=500.0, EI=self._custom,
+                         EI_kwargs={'reduction': 0.50})
+        assert got == pytest.approx(expected)
+
+    def test_callable_receives_reserved_arguments(self, rect):
+        seen = {}
+
+        def spy(section, axis, betadns, P, M, col):
+            seen.update(section=section, axis=axis, betadns=betadns,
+                        P=P, M=M, col=col)
+            return 1.0e8
+
+        rect.EIeff('x', betadns=0.3, P=100.0, M=500.0, col='COL', EI=spy)
+        assert seen['section'] is rect and seen['axis'] == 'x'
+        assert seen['betadns'] == 0.3 and seen['P'] == 100.0
+        assert seen['M'] == 500.0 and seen['col'] == 'COL'
+
+    def test_scalar_result_broadcasts_over_array_loads(self, rect):
+        values = rect.EIeff('x', P=np.array([1.0, 2.0, 3.0]),
+                            M=np.array([1.0, 2.0, 3.0]), EI=1.0e8)
+        assert values.shape == (3,) and np.all(values == 1.0e8)
+
+    def test_matching_array_result_accepted(self, rect):
+        values = rect.EIeff('x', P=np.array([1.0, 2.0]), M=np.array([1.0, 2.0]),
+                            EI=np.array([1.0e8, 2.0e8]))
+        assert np.array_equal(values, np.array([1.0e8, 2.0e8]))
+
+    def test_mismatched_array_result_rejected(self, rect):
+        with pytest.raises(ValueError, match='does not match the load shape'):
+            rect.EIeff('x', P=np.array([1.0, 2.0]), M=np.array([1.0, 2.0]),
+                       EI=np.array([1.0e8, 2.0e8, 3.0e8]))
+
+    @pytest.mark.parametrize('bad,match', [
+        (-1.0, 'positive'), (0.0, 'positive'),
+        (float('nan'), 'finite'), (float('inf'), 'finite'),
+        ('abc', 'numeric'),
+    ])
+    def test_invalid_values_rejected(self, rect, bad, match):
+        with pytest.raises(ValueError, match=match):
+            rect.EIeff('x', EI=bad)
+
+    def test_empty_result_rejected(self, rect):
+        with pytest.raises(ValueError, match='must not be empty'):
+            rect.EIeff('x', EI=np.array([]))
+
+    @pytest.mark.parametrize('reserved',
+                             ['section', 'axis', 'betadns', 'P', 'M', 'col'])
+    def test_reserved_kwarg_collision_rejected(self, rect, reserved):
+        with pytest.raises(ValueError, match='reserved'):
+            rect.EIeff('x', P=1.0, M=1.0, EI=self._custom, EI_kwargs={reserved: 1})
+
+    def test_kwargs_with_constant_rejected(self, rect):
+        with pytest.raises(ValueError, match='only meaningful when'):
+            rect.EIeff('x', EI=1.0e8, EI_kwargs={'reduction': 0.5})
+
+    def test_both_custom_channels_rejected(self, rect):
+        with pytest.raises(ValueError, match='not both'):
+            rect.EIeff('x', 1.25e8, EI=1.0e8)
+
+    def test_missing_everything_rejected(self, rect):
+        with pytest.raises(ValueError, match='must be provided'):
+            rect.EIeff('x')
+
+    def test_callable_errors_propagate(self, rect):
+        def boom(**kwargs):
+            raise RuntimeError('inside the custom callable')
+
+        with pytest.raises(RuntimeError, match='inside the custom callable'):
+            rect.EIeff('x', P=1.0, M=1.0, EI=boom)
+
+    def test_unknown_string_lists_the_builtins(self, rect):
+        with pytest.raises(ValueError, match='aci-a'):
+            rect.EIeff('x', 'no-such-method')

--- a/tests/test_rc_section.py
+++ b/tests/test_rc_section.py
@@ -456,3 +456,90 @@ class TestMaterialConstruction:
     def test_confined_material_builds_for_every_shape(self, record_section, factory):
         rec = record_section(factory(confined=True), 'x', conc_mat_type='Concrete04')
         assert len(rec.materials_of('Concrete04')) == 2, 'cover and core'
+
+
+LOAD_DEPENDENT = ['aci-c', 'jf-a', 'jf-b']
+
+
+class TestEIeffNormalization:
+    """P and M accept any numeric form; scalars in, scalars out."""
+
+    @pytest.mark.parametrize('EI_type', LOAD_DEPENDENT)
+    @pytest.mark.parametrize('P,M', [(100, 500), (100.0, 500.0),
+                                     (np.float64(100), np.float64(500)),
+                                     (np.int64(100), np.int64(500))])
+    def test_scalar_forms_agree(self, rect, EI_type, P, M):
+        """Integer input used to fall through and report an unknown EI_type."""
+        reference = rect.EIeff('x', EI_type, 0.0, P=100.0, M=500.0)
+        assert rect.EIeff('x', EI_type, 0.0, P=P, M=M) == pytest.approx(reference)
+        assert np.isscalar(rect.EIeff('x', EI_type, 0.0, P=P, M=M))
+
+    @pytest.mark.parametrize('EI_type', LOAD_DEPENDENT)
+    @pytest.mark.parametrize('container', [list, tuple, np.array])
+    def test_sequence_forms_agree(self, rect, EI_type, container):
+        values = rect.EIeff('x', EI_type, 0.0,
+                            P=container([100.0, 200.0]), M=container([500.0, 600.0]))
+        assert isinstance(values, np.ndarray) and values.shape == (2,)
+
+    @pytest.mark.parametrize('EI_type', LOAD_DEPENDENT)
+    def test_one_element_array_matches_scalar(self, rect, EI_type):
+        scalar = rect.EIeff('x', EI_type, 0.0, P=100.0, M=500.0)
+        array = rect.EIeff('x', EI_type, 0.0, P=np.array([100.0]), M=np.array([500.0]))
+        assert array[0] == pytest.approx(scalar, rel=1e-12)
+
+    @pytest.mark.parametrize('EI_type', LOAD_DEPENDENT)
+    def test_scalar_broadcasts_against_array(self, rect, EI_type):
+        values = rect.EIeff('x', EI_type, 0.0, P=np.array([100.0, 200.0]), M=500.0)
+        assert values.shape == (2,)
+
+    @pytest.mark.parametrize('EI_type', LOAD_DEPENDENT)
+    def test_incompatible_shapes_rejected(self, rect, EI_type):
+        with pytest.raises(ValueError, match='compatible shapes'):
+            rect.EIeff('x', EI_type, 0.0,
+                       P=np.array([1.0, 2.0]), M=np.array([1.0, 2.0, 3.0]))
+
+    @pytest.mark.parametrize('EI_type,bound',
+                             [('aci-c', 0.35), ('jf-a', 0.30), ('jf-b', 0.40)])
+    def test_pure_bending_returns_the_lower_bound(self, rect, EI_type, bound):
+        """P approaching 0 drives each method past its lower bound."""
+        expected = bound * rect.Ec * rect.Ig('x')
+        assert rect.EIeff('x', EI_type, 0.0, P=0.0, M=500.0) == pytest.approx(expected)
+
+    @pytest.mark.parametrize('EI_type', LOAD_DEPENDENT)
+    def test_no_load_at_all_is_undefined(self, rect, EI_type):
+        assert np.isnan(rect.EIeff('x', EI_type, 0.0, P=0.0, M=0.0))
+
+    @pytest.mark.parametrize('EI_type', LOAD_DEPENDENT)
+    def test_pure_bending_is_continuous(self, rect, EI_type):
+        near = rect.EIeff('x', EI_type, 0.0, P=1e-9, M=500.0)
+        at = rect.EIeff('x', EI_type, 0.0, P=0.0, M=500.0)
+        assert at == pytest.approx(near, rel=1e-12)
+
+    @pytest.mark.parametrize('name', ['ACI-C', ' aci-c ', 'Jf-A', ' GROSS'])
+    def test_names_are_case_and_whitespace_insensitive(self, rect, name):
+        assert np.isfinite(rect.EIeff('x', name, 0.0, P=100.0, M=500.0))
+
+    def test_jfb_scalar_and_array_agree(self, rect):
+        """The array path used signed M/P where the scalar path used magnitudes."""
+        scalar = rect.EIeff('x', 'jf-b', 0.0, P=100.0, M=500.0)
+        array = rect.EIeff('x', 'jf-b', 0.0, P=np.array([100.0]), M=np.array([500.0]))
+        assert array[0] == pytest.approx(scalar, rel=1e-15)
+
+    @pytest.mark.parametrize('EI_type', LOAD_DEPENDENT)
+    def test_missing_loads_reported_clearly(self, rect, EI_type):
+        with pytest.raises(ValueError, match='must be defined'):
+            rect.EIeff('x', EI_type, 0.0)
+
+    def test_proposed_2_requires_col(self, rect):
+        with pytest.raises(ValueError, match='col must be defined'):
+            rect.EIeff('x', 'proposed_2', 0.0, P=100.0, M=500.0)
+
+    @pytest.mark.parametrize('betadns', [-1.0, -2.0])
+    def test_betadns_at_or_below_minus_one_rejected(self, rect, betadns):
+        """betadns of -2 silently returned a negative stiffness."""
+        with pytest.raises(ValueError, match='betadns must be greater than -1'):
+            rect.EIeff('x', 'aci-a', betadns)
+
+    @pytest.mark.parametrize('betadns', [0.0, 0.6, -0.5])
+    def test_valid_betadns_gives_positive_stiffness(self, rect, betadns):
+        assert rect.EIeff('x', 'aci-a', betadns) > 0

--- a/tests/test_rc_section.py
+++ b/tests/test_rc_section.py
@@ -1,0 +1,394 @@
+"""Regression tests for the RC cross-section.
+
+Each test class corresponds to a defect fixed in the RC hardening series, plus
+an end-to-end matrix over the supported shapes, axes and confinement states.
+"""
+import numpy as np
+import pytest
+
+from conftest import make_rect, make_circle, make_obround
+from libdenavit.section import (
+    RC, Rectangle, Circle, Obround, ReinfRect, ReinfCirc, ReinfIntersectingLoops,
+)
+
+
+class TestReinforcementNormalization:
+    """A tuple of patterns used to be wrapped as a single element."""
+
+    def test_single_object_becomes_one_item_list(self, rect):
+        pattern = ReinfRect(14, 24, 3, 3, 0.79)
+        rect.reinforcement = pattern
+        assert rect.reinforcement == [pattern]
+
+    def test_list_is_copied(self, rect):
+        a, b = ReinfRect(14, 24, 3, 3, 0.79), ReinfRect(10, 20, 2, 2, 0.5)
+        source = [a, b]
+        rect.reinforcement = source
+        assert rect.reinforcement == [a, b]
+        assert rect.reinforcement is not source
+
+    def test_tuple_is_expanded_not_wrapped(self, rect):
+        a, b = ReinfRect(14, 24, 3, 3, 0.79), ReinfRect(10, 20, 2, 2, 0.5)
+        rect.reinforcement = (a, b)
+        assert rect.reinforcement == [a, b]
+        assert not isinstance(rect.reinforcement[0], tuple)
+
+    @pytest.mark.parametrize('empty', [[], ()])
+    def test_empty_rejected(self, rect, empty):
+        with pytest.raises(ValueError, match='at least one reinforcement pattern'):
+            rect.reinforcement = empty
+
+    def test_validation_reports_offending_type(self, record_section):
+        section = RC(Rectangle(30, 20), ReinfCirc(9, 8, 0.79), 4, 60, 'US')
+        with pytest.raises(ValueError, match='ReinfCirc'):
+            record_section(section, 'x')
+
+
+class TestMaximumTensileSteelStrain:
+    """coordinates is (x_array, y_array); iterating it visited the arrays."""
+
+    @staticmethod
+    def _brute_force(section, axial, kx, ky):
+        best = -np.inf
+        for pattern in section.reinforcement:
+            xs, ys = pattern.coordinates
+            for x, y in zip(xs, ys):
+                best = max(best, axial - y * kx - x * ky)
+        return best
+
+    @pytest.mark.parametrize('kx,ky', [(1e-4, 0), (0, 1e-4), (5e-5, 7e-5), (0, 0)])
+    def test_matches_brute_force(self, rect, kx, ky):
+        got = rect.maximum_tensile_steel_strain(1e-3, kx, ky)
+        assert got == pytest.approx(self._brute_force(rect, 1e-3, kx, ky), rel=1e-12)
+
+    def test_known_bar_layout(self, rect):
+        # Bars reach y = -12; the most tensile strain is 0 - (-12)*1e-4.
+        assert rect.maximum_tensile_steel_strain(0.0, 1e-4, 0) == pytest.approx(1.2e-3)
+
+    def test_zero_curvature_returns_axial_strain(self, rect):
+        assert rect.maximum_tensile_steel_strain(3.1e-3) == pytest.approx(3.1e-3)
+
+    def test_all_patterns_considered(self, rect):
+        offset = ReinfRect(8, 10, 2, 2, 0.5)
+        offset.yc = -20
+        rect.reinforcement = [ReinfRect(14, 24, 3, 3, 0.79), offset]
+        got = rect.maximum_tensile_steel_strain(1e-3, 1e-4, 0)
+        assert got == pytest.approx(self._brute_force(rect, 1e-3, 1e-4, 0), rel=1e-12)
+        # the offset pattern reaches lower than the main cage and must govern
+        assert got == pytest.approx(1e-3 + 25 * 1e-4)
+
+    def test_alias(self, rect):
+        assert rect.maximum_tensile_strain(1e-3, 1e-4) == \
+               rect.maximum_tensile_steel_strain(1e-3, 1e-4)
+
+
+class TestObroundCompressionStrain:
+    """An obround is a stadium, so its support function is exact."""
+
+    @staticmethod
+    def _dense_boundary(D, a, kx, ky, n=200001):
+        t = np.linspace(0, 2 * np.pi, n)
+        xs = np.concatenate([a / 2 + D / 2 * np.cos(t), -a / 2 + D / 2 * np.cos(t),
+                             np.linspace(-a / 2, a / 2, n), np.linspace(-a / 2, a / 2, n)])
+        ys = np.concatenate([D / 2 * np.sin(t), D / 2 * np.sin(t),
+                             np.full(n, D / 2), np.full(n, -D / 2)])
+        on_boundary = (np.abs(xs) >= a / 2) | (np.abs(np.abs(ys) - D / 2) < 1e-9)
+        return np.min(-ys[on_boundary] * abs(kx) - xs[on_boundary] * abs(ky))
+
+    @pytest.mark.parametrize('kx,ky', [(1e-4, 0), (0, 1e-4), (1e-4, 1e-4),
+                                       (3e-5, 9e-5), (2e-4, 5e-5)])
+    def test_agrees_with_dense_sampling(self, obround, kx, ky):
+        got = obround.maximum_concrete_compression_strain(0.0, kx, ky)
+        expected = self._dense_boundary(24, 12, kx, ky)
+        assert got == pytest.approx(expected, abs=1e-10)
+
+    def test_reduces_to_circle_as_flat_vanishes(self):
+        thin = RC(Obround(24, 1e-9), ReinfIntersectingLoops(20, 12, 8, 0.79), 4, 60, 'US')
+        circ = make_circle()
+        assert thin.maximum_concrete_compression_strain(0.0, 1e-4, 1e-4) == \
+               pytest.approx(circ.maximum_concrete_compression_strain(0.0, 1e-4, 1e-4), abs=1e-9)
+
+    def test_zero_curvature_returns_axial_strain(self, obround):
+        assert obround.maximum_concrete_compression_strain(2e-3) == pytest.approx(2e-3)
+
+
+class TestInteractionDiagramCache:
+    """One cached object used to answer every parameter combination."""
+
+    def test_axes_do_not_share_entries(self, rect):
+        assert rect.interaction_diagram_object('x', 8) is not \
+               rect.interaction_diagram_object('y', 8)
+
+    def test_identical_requests_are_reused(self, rect):
+        assert rect.interaction_diagram_object('x', 8) is \
+               rect.interaction_diagram_object('x', 8)
+
+    @pytest.mark.parametrize('kwargs', [
+        {'factored': True}, {'only_compressive': False}, {'num_points': 10},
+    ])
+    def test_parameters_do_not_share_entries(self, rect, kwargs):
+        base = rect.interaction_diagram_object('x', num_points=8)
+        kwargs = {'num_points': 8, **kwargs}
+        assert rect.interaction_diagram_object('x', **kwargs) is not base
+
+    @pytest.mark.parametrize('attribute,value', [
+        ('Ec', 4000.0), ('Es', 29500.0), ('eps_c', 0.0021),
+    ])
+    def test_setters_invalidate(self, rect, attribute, value):
+        rect.interaction_diagram_object('x', 8)
+        setattr(rect, attribute, value)
+        assert rect._CS_id2d == {}
+
+    def test_reinforcement_setter_invalidates(self, rect):
+        rect.interaction_diagram_object('x', 8)
+        rect.reinforcement = ReinfRect(14, 24, 4, 4, 0.79)
+        assert rect._CS_id2d == {}
+
+
+class TestAci209Inputs:
+    """ACI 209R-92 corrections take percentages, not fractions."""
+
+    @pytest.mark.parametrize('units', ['us', 'si'])
+    def test_defaults_are_finite(self, units):
+        section = RC(Rectangle(30, 20), ReinfRect(14, 24, 3, 3, 0.79), 4, 60, units)
+        for props in (section.get_creep_props_for_uniaxial_material(),
+                      section.get_shrinkage_props_for_uniaxial_material()):
+            assert all(np.isfinite(v) for v in props.values())
+
+    @pytest.mark.parametrize('units', ['us', 'si'])
+    def test_reference_values_reproduce_defaults(self, units):
+        """psi=50% and alpha=6% are the ACI 209 reference values."""
+        section = RC(Rectangle(30, 20), ReinfRect(14, 24, 3, 3, 0.79), 4, 60, units)
+        assert section.get_creep_props_for_uniaxial_material(
+            fine_agg_ratio=50, air_content=6) == \
+            section.get_creep_props_for_uniaxial_material()
+
+    def test_air_content_scales_as_percentage_points(self):
+        section = make_rect()
+        base = section.get_creep_props_for_uniaxial_material()['phi_u']
+        richer = section.get_creep_props_for_uniaxial_material(air_content=8)['phi_u']
+        # gamma_c_a = 0.46 + 0.09*8 = 1.18
+        assert richer == pytest.approx(base * 1.18, rel=1e-9)
+
+    def test_optional_dictionaries_may_be_omitted(self):
+        """build_ops_fiber_section expanded None with **, raising TypeError."""
+        section = make_rect()
+        assert section.get_creep_props_for_uniaxial_material(**(None or {}))
+        assert section.get_shrinkage_props_for_uniaxial_material(**(None or {}))
+
+    @pytest.mark.parametrize('rh', [0.2, 1.5])
+    def test_invalid_relative_humidity_rejected(self, rh):
+        with pytest.raises(ValueError, match='Relative humidity'):
+            make_rect().get_shrinkage_props_for_uniaxial_material(RH=rh)
+
+
+class TestAxisMapping:
+    """x bending uses y coordinates and nfy; y bending uses x and nfx."""
+
+    def test_rectangle_uses_axis_appropriate_bar_coordinates(self, record_section):
+        section = make_rect()
+        xs, ys = section.reinforcement[0].coordinates
+        assert record_section(section, 'x').steel_positions == \
+               sorted({round(v, 9) for v in ys})
+        assert record_section(section, 'y').steel_positions == \
+               sorted({round(v, 9) for v in xs})
+
+    def test_circle_y_bending_uses_x_coordinates(self, record_section):
+        section = make_circle(num_bars=6)   # 6 bars -> x and y sets differ
+        xs, ys = section.reinforcement[0].coordinates
+        positions = record_section(section, 'y').steel_positions
+        for x in xs:
+            assert round(float(x), 9) in positions
+
+    @pytest.mark.parametrize('factory', [make_rect, make_circle, make_obround])
+    @pytest.mark.parametrize('axis,changed,unchanged', [('x', 'nfy', 'nfx'),
+                                                        ('y', 'nfx', 'nfy')])
+    def test_only_the_active_direction_refines(self, record_section, factory,
+                                               axis, changed, unchanged):
+        section = factory()
+        base = record_section(section, axis, nfy=20, nfx=20).total_fibers
+        refined = record_section(section, axis,
+                                 **{changed: 40, unchanged: 20}).total_fibers
+        inert = record_section(section, axis,
+                               **{unchanged: 40, changed: 20}).total_fibers
+        assert refined > base, f'{changed} should refine {axis} bending'
+        assert inert == base, f'{unchanged} must be ignored for {axis} bending'
+
+    def test_rectangle_cover_depth_uses_the_bending_direction(self, record_section):
+        """cdb used By for both axes, giving negative cover about y."""
+        reinf = ReinfRect(10, 24, 3, 5, 0.79)   # Bx=10, By=24
+        reinf.db = 1.0
+        section = RC(Rectangle(30, 20), reinf, 4, 60, 'US', dbt=0.5, s=4, fyt=60)
+        for axis, depth, reinf_depth in [('x', 30, 24), ('y', 20, 10)]:
+            layers = record_section(section, axis, conc_mat_type='Concrete04').layers
+            expected_cdb = (depth - reinf_depth) / 2 - 1.0 / 2 - 0.5 / 2
+            core = layers[0]['coords']
+            strip = (core[2] - core[0]) / (layers[0]['n'] - 1) if layers[0]['n'] > 1 else 0
+            assert core[0] < 0 < core[2], 'core layer must straddle the centroid'
+            assert -depth / 2 + expected_cdb == pytest.approx(core[0] - strip / 2, abs=1e-9)
+
+    @pytest.mark.parametrize('factory', [make_rect, make_circle, make_obround])
+    def test_unsupported_axis_rejected(self, record_section, factory):
+        with pytest.raises(ValueError, match='axis'):
+            record_section(factory(), 'z')
+
+
+class TestConcreteFiberPlacement:
+    """Layer endpoints are fiber centers, so strips sit at their centroids."""
+
+    @pytest.mark.parametrize('nfy', [1, 2, 4, 10, 20])
+    def test_total_area_is_exact(self, record_section, nfy):
+        fibers = record_section(make_rect(), 'x', nfy=nfy).layer_fibers()
+        assert sum(a for _, a in fibers) == pytest.approx(30 * 20, rel=1e-12)
+
+    @pytest.mark.parametrize('nfy', [2, 4, 10, 20])
+    def test_centroid_is_exact(self, record_section, nfy):
+        fibers = record_section(make_rect(), 'x', nfy=nfy).layer_fibers()
+        total = sum(a for _, a in fibers)
+        assert sum(y * a for y, a in fibers) / total == pytest.approx(0.0, abs=1e-9)
+
+    def test_second_moment_converges(self, record_section):
+        exact = 20 * 30 ** 3 / 12
+        errors = []
+        for nfy in [4, 8, 16, 32]:
+            fibers = record_section(make_rect(), 'x', nfy=nfy).layer_fibers()
+            I = sum(a * y ** 2 for y, a in fibers)
+            errors.append(abs(I - exact) / exact)
+        assert all(b < a for a, b in zip(errors, errors[1:])), errors
+        # second order convergence: each refinement cuts the error about 4x
+        assert errors[-1] < errors[0] / 30
+
+    @pytest.mark.parametrize('nfy', [1, 2, 5, 20])
+    def test_no_fiber_lies_outside_the_section(self, record_section, nfy):
+        fibers = record_section(make_rect(), 'x', nfy=nfy).layer_fibers()
+        assert max(abs(y) for y, _ in fibers) <= 30 / 2 + 1e-12
+
+    @pytest.mark.parametrize('nfy', [10, 20, 40])
+    def test_confined_cover_plus_core_equals_gross(self, record_section, nfy):
+        fibers = record_section(make_rect(confined=True), 'x', nfy=nfy,
+                                conc_mat_type='Concrete04').layer_fibers()
+        assert sum(a for _, a in fibers) == pytest.approx(30 * 20, rel=1e-12)
+
+    @pytest.mark.parametrize('bad', [0, -3, 2.5, '20', True])
+    def test_fiber_counts_validated(self, record_section, bad):
+        with pytest.raises(ValueError, match='positive integer'):
+            record_section(make_rect(), 'x', nfy=bad)
+
+
+class TestConfinementValidation:
+    """Confinement needs transverse reinforcement and a feasible core."""
+
+    @pytest.mark.parametrize('missing', ['dbt', 's', 'fyt'])
+    def test_missing_transverse_property_rejected(self, missing):
+        kwargs = dict(dbt=0.5, s=4, fyt=60)
+        kwargs[missing] = None
+        with pytest.raises(ValueError, match=missing):
+            make_rect(**kwargs).confined_concrete_props()
+
+    @pytest.mark.parametrize('name,value', [('dbt', 0), ('dbt', -1), ('s', 0), ('fyt', -60)])
+    def test_non_positive_values_rejected(self, name, value):
+        kwargs = dict(dbt=0.5, s=4, fyt=60)
+        kwargs[name] = value
+        with pytest.raises(ValueError, match='finite positive'):
+            make_rect(**kwargs).confined_concrete_props()
+
+    @pytest.mark.parametrize('s', [0.2, 0.5])
+    def test_spacing_must_exceed_bar_diameter(self, s):
+        """s <= dbt gave negative clear spacing and inflated fcc silently."""
+        with pytest.raises(ValueError, match='clear spacing'):
+            make_rect(dbt=0.5, s=s, fyt=60).confined_concrete_props()
+
+    def test_single_bar_per_side_rejected(self):
+        reinf = ReinfRect(14, 24, 1, 3, 0.79)
+        reinf.db = 1.0
+        section = RC(Rectangle(30, 20), reinf, 4, 60, 'US', dbt=0.5, s=4, fyt=60)
+        with pytest.raises(ValueError, match='at least 2 bars'):
+            section.confined_concrete_props()
+
+    @pytest.mark.parametrize('factory', [make_rect, make_circle, make_obround])
+    def test_valid_geometry_is_confined(self, factory):
+        section = factory(confined=True)
+        fcc, eps_cc = section.confined_concrete_props()
+        assert np.isfinite(fcc) and np.isfinite(eps_cc)
+        assert fcc > section.fc, 'confinement must increase strength'
+        assert eps_cc > section.eps_c, 'confinement must increase ductility'
+
+    def test_unconfined_obround_needs_no_transverse_reinforcement(self, record_section):
+        """ds was built from dbt before the confinement branch was chosen."""
+        section = make_obround()
+        assert section.dbt is None
+        assert record_section(section, 'x').fibers
+
+
+class TestEIeff:
+    """Built-in effective stiffness methods."""
+
+    @pytest.mark.parametrize('EI_type', ['aci-a', 'aci-b'])
+    def test_load_independent_methods(self, rect, EI_type):
+        value = rect.EIeff('x', EI_type, 0.0)
+        assert np.isfinite(value) and value > 0
+
+    def test_scalar_load_dependent_method(self, rect):
+        value = rect.EIeff('x', 'aci-c', 0.0, P=100.0, M=500.0)
+        assert np.isfinite(value) and value > 0
+
+    def test_array_loads(self, rect):
+        P = np.array([100.0, 200.0, 300.0])
+        M = np.array([500.0, 600.0, 700.0])
+        values = rect.EIeff('x', 'aci-c', 0.0, P=P, M=M)
+        assert np.shape(values) == P.shape
+        assert np.all(np.isfinite(values))
+
+    def test_one_element_array_matches_scalar(self, rect):
+        scalar = rect.EIeff('x', 'aci-c', 0.0, P=100.0, M=500.0)
+        array = rect.EIeff('x', 'aci-c', 0.0, P=np.array([100.0]), M=np.array([500.0]))
+        assert np.ravel(array)[0] == pytest.approx(scalar, rel=1e-12)
+
+    def test_unknown_method_reports_clearly(self, rect):
+        with pytest.raises(ValueError, match='Unknown EI_type'):
+            rect.EIeff('x', 'no-such-method')
+
+    def test_user_function_errors_are_not_masked(self, rect, monkeypatch):
+        """A bare except reported real errors as an unknown EI_type."""
+        import sys
+        import types
+
+        module = types.ModuleType('exploding_ei')
+
+        def exploding_ei(*args, **kwargs):
+            raise RuntimeError('failure inside the user function')
+
+        module.exploding_ei = exploding_ei
+        monkeypatch.setitem(sys.modules, 'exploding_ei', module)
+        with pytest.raises(RuntimeError, match='inside the user function'):
+            rect.EIeff('x', 'exploding_ei,0.5')
+
+
+class TestEndToEnd:
+    """Every supported shape, axis and confinement state builds a section."""
+
+    @pytest.mark.parametrize('factory', [make_rect, make_circle, make_obround])
+    @pytest.mark.parametrize('axis', ['x', 'y'])
+    def test_unconfined(self, record_section, factory, axis):
+        recorder = record_section(factory(), axis)
+        assert recorder.fibers or recorder.layers
+
+    @pytest.mark.parametrize('factory', [make_rect, make_circle, make_obround])
+    @pytest.mark.parametrize('axis', ['x', 'y'])
+    def test_confined(self, record_section, factory, axis):
+        recorder = record_section(factory(confined=True), axis,
+                                  conc_mat_type='Concrete04')
+        assert recorder.fibers or recorder.layers
+
+    @pytest.mark.parametrize('axis', ['x', 'y'])
+    def test_interaction_diagrams_are_axis_specific(self, rect, axis):
+        P, M, _ = rect.section_interaction_2d(axis, 8, factored=False,
+                                              only_compressive=True)
+        assert len(P) == len(M) > 0
+        assert np.all(np.isfinite(P)) and np.all(np.isfinite(M))
+
+    def test_interaction_diagrams_differ_between_axes(self):
+        section = RC(Rectangle(30, 20), ReinfRect(14, 24, 3, 3, 0.79), 4, 60, 'US')
+        _, Mx, _ = section.section_interaction_2d('x', 8)
+        _, My, _ = section.section_interaction_2d('y', 8)
+        assert not np.allclose(Mx, My), 'a 30x20 section is not axis-symmetric'


### PR DESCRIPTION
Corrects strain, fiber-placement, and axis-mapping errors in `RC.py`, several
`EIeff` methods, and the 1.4Mu and AASHTO sweeps. Adds 262 tests.